### PR TITLE
fix: support nuxt typecheck in apps extending docus

### DIFF
--- a/layer/app/components/app/AppFooterRight.vue
+++ b/layer/app/components/app/AppFooterRight.vue
@@ -1,20 +1,38 @@
 <script setup lang="ts">
 const appConfig = useAppConfig()
 
-const links = computed(() => [
-  ...Object.entries(appConfig.socials || {}).map(([key, url]) => ({
-    'icon': `i-simple-icons-${key}`,
-    'to': url,
-    'target': '_blank',
-    'aria-label': `${key} social link`,
-  })),
-  appConfig.github && appConfig.github.url && {
-    'icon': 'i-simple-icons-github',
-    'to': appConfig.github.url,
-    'target': '_blank',
-    'aria-label': 'GitHub repository',
-  },
-].filter(Boolean))
+interface FooterLink {
+  icon: string
+  to: string
+  target: '_blank'
+  'aria-label': string
+}
+
+const links = computed<FooterLink[]>(() => {
+  const socialLinks = Object.entries(appConfig.socials || {}).flatMap(([key, url]) => {
+    if (typeof url !== 'string' || !url) {
+      return []
+    }
+
+    return [{
+      icon: `i-simple-icons-${key}`,
+      to: url,
+      target: '_blank' as const,
+      'aria-label': `${key} social link`,
+    }]
+  })
+
+  const githubLink = appConfig.github && appConfig.github.url
+    ? [{
+        icon: 'i-simple-icons-github',
+        to: appConfig.github.url,
+        target: '_blank' as const,
+        'aria-label': 'GitHub repository',
+      }]
+    : []
+
+  return [...socialLinks, ...githubLink]
+})
 </script>
 
 <template>

--- a/layer/app/composables/useDocusI18n.ts
+++ b/layer/app/composables/useDocusI18n.ts
@@ -1,10 +1,22 @@
-import { useI18n, useLocalePath, useNuxtApp, useRuntimeConfig, useSwitchLocalePath } from '#imports'
+import { useNuxtApp, useRuntimeConfig } from '#imports'
 import type { LocaleObject } from '@nuxtjs/i18n'
+import type { Ref } from 'vue'
 import { ref } from 'vue'
+
+type DocusNuxtApp = ReturnType<typeof useNuxtApp> & {
+  $i18n?: {
+    locale: Ref<string>
+    t: (key: string) => string
+  }
+  $locale?: string
+  $localeMessages?: Record<string, unknown>
+  $localePath?: (path: string) => string
+  $switchLocalePath?: (locale?: string) => string
+}
 
 export const useDocusI18n = () => {
   const config = useRuntimeConfig().public
-  const nuxtApp = useNuxtApp()
+  const nuxtApp = useNuxtApp() as DocusNuxtApp
   const isEnabled = ref(!!config.i18n)
 
   if (!isEnabled.value) {
@@ -24,15 +36,16 @@ export const useDocusI18n = () => {
     }
   }
 
-  const { locale, t } = useI18n()
-  const filteredLocales: LocaleObject<string>[] = config.docus?.filteredLocales || []
+  const locale = nuxtApp.$i18n?.locale || ref('en')
+  const t = nuxtApp.$i18n?.t || ((key: string) => key)
+  const filteredLocales = (config.docus as { filteredLocales: LocaleObject<string>[] })?.filteredLocales || []
 
   return {
     isEnabled,
     locale,
     locales: filteredLocales,
     t,
-    localePath: useLocalePath(),
-    switchLocalePath: useSwitchLocalePath(),
+    localePath: nuxtApp.$localePath || ((path: string) => path),
+    switchLocalePath: nuxtApp.$switchLocalePath || (() => ''),
   }
 }

--- a/layer/app/composables/useDocusI18n.ts
+++ b/layer/app/composables/useDocusI18n.ts
@@ -1,22 +1,10 @@
-import { useNuxtApp, useRuntimeConfig } from '#imports'
+import { useI18n, useLocalePath, useNuxtApp, useRuntimeConfig, useSwitchLocalePath } from '#imports'
 import type { LocaleObject } from '@nuxtjs/i18n'
-import type { Ref } from 'vue'
 import { ref } from 'vue'
-
-type DocusNuxtApp = ReturnType<typeof useNuxtApp> & {
-  $i18n?: {
-    locale: Ref<string>
-    t: (key: string) => string
-  }
-  $locale?: string
-  $localeMessages?: Record<string, unknown>
-  $localePath?: (path: string) => string
-  $switchLocalePath?: (locale?: string) => string
-}
 
 export const useDocusI18n = () => {
   const config = useRuntimeConfig().public
-  const nuxtApp = useNuxtApp() as DocusNuxtApp
+  const nuxtApp = useNuxtApp()
   const isEnabled = ref(!!config.i18n)
 
   if (!isEnabled.value) {
@@ -36,16 +24,15 @@ export const useDocusI18n = () => {
     }
   }
 
-  const locale = nuxtApp.$i18n?.locale || ref('en')
-  const t = nuxtApp.$i18n?.t || ((key: string) => key)
-  const filteredLocales = (config.docus as { filteredLocales: LocaleObject<string>[] })?.filteredLocales || []
+  const { locale, t } = useI18n()
+  const filteredLocales: LocaleObject<string>[] = config.docus?.filteredLocales || []
 
   return {
     isEnabled,
     locale,
     locales: filteredLocales,
     t,
-    localePath: nuxtApp.$localePath || ((path: string) => path),
-    switchLocalePath: nuxtApp.$switchLocalePath || (() => ''),
+    localePath: useLocalePath(),
+    switchLocalePath: useSwitchLocalePath(),
   }
 }

--- a/layer/app/composables/useDocusI18n.ts
+++ b/layer/app/composables/useDocusI18n.ts
@@ -1,12 +1,27 @@
+import { useNuxtApp, useRuntimeConfig } from '#imports'
 import type { LocaleObject } from '@nuxtjs/i18n'
+import type { Ref } from 'vue'
+import { ref } from 'vue'
+
+type DocusNuxtApp = ReturnType<typeof useNuxtApp> & {
+  $i18n?: {
+    locale: Ref<string>
+    t: (key: string) => string
+  }
+  $locale?: string
+  $localeMessages?: Record<string, unknown>
+  $localePath?: (path: string) => string
+  $switchLocalePath?: (locale?: string) => string
+}
 
 export const useDocusI18n = () => {
   const config = useRuntimeConfig().public
+  const nuxtApp = useNuxtApp() as DocusNuxtApp
   const isEnabled = ref(!!config.i18n)
 
   if (!isEnabled.value) {
-    const locale = useNuxtApp().$locale as string
-    const localeMessages = useNuxtApp().$localeMessages as Record<string, unknown>
+    const locale = nuxtApp.$locale || 'en'
+    const localeMessages = nuxtApp.$localeMessages || {}
 
     return {
       isEnabled,
@@ -21,7 +36,8 @@ export const useDocusI18n = () => {
     }
   }
 
-  const { locale, t } = useI18n()
+  const locale = nuxtApp.$i18n?.locale || ref('en')
+  const t = nuxtApp.$i18n?.t || ((key: string) => key)
   const filteredLocales = (config.docus as { filteredLocales: LocaleObject<string>[] })?.filteredLocales || []
 
   return {
@@ -29,7 +45,7 @@ export const useDocusI18n = () => {
     locale,
     locales: filteredLocales,
     t,
-    localePath: useLocalePath(),
-    switchLocalePath: useSwitchLocalePath(),
+    localePath: nuxtApp.$localePath || ((path: string) => path),
+    switchLocalePath: nuxtApp.$switchLocalePath || (() => ''),
   }
 }

--- a/layer/app/composables/useLogoAssets.ts
+++ b/layer/app/composables/useLogoAssets.ts
@@ -1,4 +1,5 @@
 import type { ContextMenuItem } from '@nuxt/ui'
+import { useNuxtApp } from '#imports'
 
 function isSvgUrl(url: string): boolean {
   return url.toLowerCase().endsWith('.svg')
@@ -65,7 +66,7 @@ function triggerLinkDownload(url: string, filename: string) {
 
 export const useLogoAssets = () => {
   const appConfig = useAppConfig()
-  const colorMode = useColorMode() as { value: string, forced?: boolean }
+  const colorMode = useNuxtApp().$colorMode
   const toast = useToast()
   const { t } = useDocusI18n()
 

--- a/layer/app/composables/useLogoAssets.ts
+++ b/layer/app/composables/useLogoAssets.ts
@@ -65,7 +65,7 @@ function triggerLinkDownload(url: string, filename: string) {
 
 export const useLogoAssets = () => {
   const appConfig = useAppConfig()
-  const colorMode = useColorMode()
+  const colorMode = useColorMode() as { value: string, forced?: boolean }
   const toast = useToast()
   const { t } = useDocusI18n()
 

--- a/layer/app/composables/useLogoAssets.ts
+++ b/layer/app/composables/useLogoAssets.ts
@@ -1,5 +1,4 @@
 import type { ContextMenuItem } from '@nuxt/ui'
-import { useNuxtApp } from '#imports'
 
 function isSvgUrl(url: string): boolean {
   return url.toLowerCase().endsWith('.svg')
@@ -66,7 +65,7 @@ function triggerLinkDownload(url: string, filename: string) {
 
 export const useLogoAssets = () => {
   const appConfig = useAppConfig()
-  const colorMode = useNuxtApp().$colorMode
+  const colorMode = useColorMode() as { value: string, forced?: boolean }
   const toast = useToast()
   const { t } = useDocusI18n()
 

--- a/layer/app/types/index.d.ts
+++ b/layer/app/types/index.d.ts
@@ -1,4 +1,3 @@
-import type { LocaleObject } from '@nuxtjs/i18n'
 import type { FaqQuestions, LocalizedFaqQuestions } from '../../modules/assistant/runtime/types'
 
 export type { FaqCategory, FaqQuestions, LocalizedFaqQuestions } from '../../modules/assistant/runtime/types'
@@ -94,19 +93,6 @@ declare module 'nuxt/schema' {
         explain?: string
       }
     }
-  }
-
-  interface PublicRuntimeConfig {
-    docus?: {
-      filteredLocales?: LocaleObject<string>[]
-    }
-  }
-}
-
-declare module '#app' {
-  interface NuxtApp {
-    $locale?: string
-    $localeMessages?: Record<string, unknown>
   }
 }
 

--- a/layer/app/types/index.d.ts
+++ b/layer/app/types/index.d.ts
@@ -1,3 +1,4 @@
+import type { LocaleObject } from '@nuxtjs/i18n'
 import type { FaqQuestions, LocalizedFaqQuestions } from '../../modules/assistant/runtime/types'
 
 export type { FaqCategory, FaqQuestions, LocalizedFaqQuestions } from '../../modules/assistant/runtime/types'
@@ -93,6 +94,19 @@ declare module 'nuxt/schema' {
         explain?: string
       }
     }
+  }
+
+  interface PublicRuntimeConfig {
+    docus?: {
+      filteredLocales?: LocaleObject<string>[]
+    }
+  }
+}
+
+declare module '#app' {
+  interface NuxtApp {
+    $locale?: string
+    $localeMessages?: Record<string, unknown>
   }
 }
 

--- a/layer/modules/assistant/runtime/components/AssistantPreStream.vue
+++ b/layer/modules/assistant/runtime/components/AssistantPreStream.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ShikiCachedRenderer } from 'shiki-stream/vue'
-import { useColorMode } from '#imports'
+import { useNuxtApp } from '#imports'
 import { useHighlighter } from '../composables/useHighlighter'
 
-const colorMode = useColorMode() as { value: string, forced?: boolean }
+const colorMode = useNuxtApp().$colorMode
 const highlighter = await useHighlighter()
 const props = defineProps<{
   code: string

--- a/layer/modules/assistant/runtime/components/AssistantPreStream.vue
+++ b/layer/modules/assistant/runtime/components/AssistantPreStream.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { ShikiCachedRenderer } from 'shiki-stream/vue'
-import { useNuxtApp } from '#imports'
+import { useColorMode } from '#imports'
 import { useHighlighter } from '../composables/useHighlighter'
 
-const colorMode = useNuxtApp().$colorMode
+const colorMode = useColorMode() as { value: string, forced?: boolean }
 const highlighter = await useHighlighter()
 const props = defineProps<{
   code: string

--- a/layer/modules/assistant/runtime/components/AssistantPreStream.vue
+++ b/layer/modules/assistant/runtime/components/AssistantPreStream.vue
@@ -3,7 +3,7 @@ import { ShikiCachedRenderer } from 'shiki-stream/vue'
 import { useColorMode } from '#imports'
 import { useHighlighter } from '../composables/useHighlighter'
 
-const colorMode = useColorMode()
+const colorMode = useColorMode() as { value: string, forced?: boolean }
 const highlighter = await useHighlighter()
 const props = defineProps<{
   code: string

--- a/layer/modules/assistant/runtime/composables/useAssistant.ts
+++ b/layer/modules/assistant/runtime/composables/useAssistant.ts
@@ -25,7 +25,10 @@ const PANEL_WIDTH_EXPANDED = 520
 export function useAssistant() {
   const config = useRuntimeConfig()
   const appConfig = useAppConfig()
-  const isEnabled = computed(() => config.public.assistant?.enabled ?? false)
+  const assistantRuntimeConfig = config.public.assistant as { enabled?: boolean } | undefined
+  const assistantConfig = appConfig.assistant as { faqQuestions?: FaqQuestions | LocalizedFaqQuestions } | undefined
+  const docusRuntimeConfig = appConfig.docus as { locale?: string } | undefined
+  const isEnabled = computed(() => assistantRuntimeConfig?.enabled ?? false)
 
   const isOpen = useState('assistant-open', () => false)
   const isExpanded = useState('assistant-expanded', () => false)
@@ -37,13 +40,13 @@ export function useAssistant() {
   const shouldPushContent = computed(() => !isMobile.value && isOpen.value)
 
   const faqQuestions = computed<FaqCategory[]>(() => {
-    const faqConfig = appConfig.assistant?.faqQuestions
+    const faqConfig = assistantConfig?.faqQuestions
     if (!faqConfig) return []
 
     // Check if it's a localized object (has locale keys like 'en', 'fr')
     if (!Array.isArray(faqConfig)) {
       const localizedConfig = faqConfig as LocalizedFaqQuestions
-      const currentLocale = appConfig.docus?.locale || 'en'
+      const currentLocale = docusRuntimeConfig?.locale || 'en'
       const defaultLocale = config.public.i18n?.defaultLocale || 'en'
 
       // Try current locale, then default locale, then first available

--- a/layer/modules/assistant/runtime/composables/useAssistant.ts
+++ b/layer/modules/assistant/runtime/composables/useAssistant.ts
@@ -25,10 +25,7 @@ const PANEL_WIDTH_EXPANDED = 520
 export function useAssistant() {
   const config = useRuntimeConfig()
   const appConfig = useAppConfig()
-  const assistantRuntimeConfig = config.public.assistant as { enabled?: boolean } | undefined
-  const assistantConfig = appConfig.assistant as { faqQuestions?: FaqQuestions | LocalizedFaqQuestions } | undefined
-  const docusRuntimeConfig = appConfig.docus as { locale?: string } | undefined
-  const isEnabled = computed(() => assistantRuntimeConfig?.enabled ?? false)
+  const isEnabled = computed(() => config.public.assistant?.enabled ?? false)
 
   const isOpen = useState('assistant-open', () => false)
   const isExpanded = useState('assistant-expanded', () => false)
@@ -40,13 +37,13 @@ export function useAssistant() {
   const shouldPushContent = computed(() => !isMobile.value && isOpen.value)
 
   const faqQuestions = computed<FaqCategory[]>(() => {
-    const faqConfig = assistantConfig?.faqQuestions
+    const faqConfig = appConfig.assistant?.faqQuestions
     if (!faqConfig) return []
 
     // Check if it's a localized object (has locale keys like 'en', 'fr')
     if (!Array.isArray(faqConfig)) {
       const localizedConfig = faqConfig as LocalizedFaqQuestions
-      const currentLocale = docusRuntimeConfig?.locale || 'en'
+      const currentLocale = appConfig.docus?.locale || 'en'
       const defaultLocale = config.public.i18n?.defaultLocale || 'en'
 
       // Try current locale, then default locale, then first available

--- a/layer/modules/assistant/runtime/composables/useAssistant.ts
+++ b/layer/modules/assistant/runtime/composables/useAssistant.ts
@@ -25,7 +25,10 @@ const PANEL_WIDTH_EXPANDED = 520
 export function useAssistant() {
   const config = useRuntimeConfig()
   const appConfig = useAppConfig()
-  const isEnabled = computed(() => config.public.assistant?.enabled ?? false)
+  const assistantRuntimeConfig = config.public.assistant as { enabled?: boolean } | undefined
+  const assistantConfig = appConfig.assistant as { faqQuestions?: FaqQuestions | LocalizedFaqQuestions } | undefined
+  const docusRuntimeConfig = appConfig.docus as { locale?: string } | undefined
+  const isEnabled = computed(() => assistantRuntimeConfig?.enabled ?? false)
 
   const isOpen = useState('assistant-open', () => false)
   const isExpanded = useState('assistant-expanded', () => false)
@@ -37,14 +40,13 @@ export function useAssistant() {
   const shouldPushContent = computed(() => !isMobile.value && isOpen.value)
 
   const faqQuestions = computed<FaqCategory[]>(() => {
-    const assistantConfig = appConfig.assistant
     const faqConfig = assistantConfig?.faqQuestions
     if (!faqConfig) return []
 
     // Check if it's a localized object (has locale keys like 'en', 'fr')
     if (!Array.isArray(faqConfig)) {
       const localizedConfig = faqConfig as LocalizedFaqQuestions
-      const currentLocale = appConfig.docus?.locale || 'en'
+      const currentLocale = docusRuntimeConfig?.locale || 'en'
       const defaultLocale = config.public.i18n?.defaultLocale || 'en'
 
       // Try current locale, then default locale, then first available

--- a/layer/modules/assistant/runtime/composables/useAssistant.ts
+++ b/layer/modules/assistant/runtime/composables/useAssistant.ts
@@ -1,5 +1,7 @@
 import type { UIMessage } from 'ai'
+import { useAppConfig, useRuntimeConfig, useState } from '#imports'
 import { useMediaQuery } from '@vueuse/core'
+import { computed } from 'vue'
 import type { FaqCategory, FaqQuestions, LocalizedFaqQuestions } from '../types'
 
 function normalizeFaqQuestions(questions: FaqQuestions): FaqCategory[] {

--- a/layer/modules/config.ts
+++ b/layer/modules/config.ts
@@ -7,6 +7,13 @@ import { getGitBranch, getGitEnv, getLocalGitInfo } from '../utils/git'
 
 const log = logger.withTag('Docus')
 
+type I18nLocale = string | { code: string, name?: string }
+type DocusI18nOptions = { locales?: I18nLocale[], strategy?: string }
+type RegisterModuleOptions = {
+  langDir: string
+  locales: Array<{ code: string, name: string, file: string }>
+}
+
 export default defineNuxtModule({
   meta: {
     name: 'config',
@@ -54,11 +61,14 @@ export default defineNuxtModule({
     /*
     ** I18N
     */
-    if (nuxt.options.i18n && nuxt.options.i18n.locales) {
+    const typedNuxtOptions = nuxt.options as typeof nuxt.options & { i18n?: DocusI18nOptions }
+    const i18nOptions = typedNuxtOptions.i18n
+
+    if (i18nOptions?.locales) {
       const { resolve } = createResolver(import.meta.url)
 
       // Filter locales to only include existing ones
-      const filteredLocales = nuxt.options.i18n.locales.filter((locale) => {
+      const filteredLocales = i18nOptions.locales.filter((locale: I18nLocale) => {
         const localeCode = typeof locale === 'string' ? locale : locale.code
 
         // Check for JSON locale file
@@ -81,8 +91,8 @@ export default defineNuxtModule({
       })
 
       // Override strategy to prefix
-      nuxt.options.i18n = {
-        ...nuxt.options.i18n,
+      typedNuxtOptions.i18n = {
+        ...i18nOptions,
         strategy: 'prefix',
       }
 
@@ -91,10 +101,12 @@ export default defineNuxtModule({
         filteredLocales,
       }
 
-      nuxt.hook('i18n:registerModule', (register) => {
+      const registerI18nModule = nuxt.hook as unknown as (name: string, callback: (register: (options: RegisterModuleOptions) => void) => void) => void
+
+      registerI18nModule('i18n:registerModule', (register) => {
         const langDir = resolve('../i18n/locales')
 
-        const locales = filteredLocales?.map((locale) => {
+        const locales = filteredLocales.map((locale: I18nLocale) => {
           return typeof locale === 'string'
             ? {
                 code: locale,

--- a/layer/modules/markdown-rewrite.ts
+++ b/layer/modules/markdown-rewrite.ts
@@ -4,6 +4,9 @@ import { readFile, writeFile } from 'node:fs/promises'
 
 const log = logger.withTag('Docus')
 
+type I18nLocale = string | { code: string }
+type DocusI18nOptions = { locales?: I18nLocale[] }
+
 export default defineNuxtModule({
   meta: {
     name: 'markdown-rewrite',
@@ -44,13 +47,14 @@ export default defineNuxtModule({
         ]
 
         // Check if i18n is enabled
-        const isI18nEnabled = !!(nuxt.options.i18n && nuxt.options.i18n.locales)
+        const i18nOptions = (nuxt.options as typeof nuxt.options & { i18n?: DocusI18nOptions }).i18n
+        const isI18nEnabled = !!i18nOptions?.locales
         let localeCodes: string[] = []
 
         if (isI18nEnabled) {
           // Get locale codes
-          const locales = nuxt.options.i18n.locales || []
-          localeCodes = locales.map((locale) => {
+          const locales = i18nOptions?.locales || []
+          localeCodes = locales.map((locale: I18nLocale) => {
             return typeof locale === 'string' ? locale : locale.code
           })
 

--- a/layer/modules/routing.ts
+++ b/layer/modules/routing.ts
@@ -1,6 +1,8 @@
 import { defineNuxtModule, extendPages, createResolver } from '@nuxt/kit'
 import { landingPageExists } from '../utils/pages'
 
+type DocusI18nOptions = { locales?: Array<string | { code: string }> }
+
 export default defineNuxtModule({
   meta: {
     name: 'routing',
@@ -8,7 +10,8 @@ export default defineNuxtModule({
   async setup(_options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
 
-    const isI18nEnabled = !!(nuxt.options.i18n && nuxt.options.i18n.locales)
+    const i18nOptions = (nuxt.options as typeof nuxt.options & { i18n?: DocusI18nOptions }).i18n
+    const isI18nEnabled = !!i18nOptions?.locales
 
     // Ensure useDocusI18n is available in the app
     nuxt.hook('imports:extend', (imports) => {

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -2,6 +2,8 @@ import { extendViteConfig, createResolver, useNuxt } from '@nuxt/kit'
 
 const { resolve } = createResolver(import.meta.url)
 
+type DocusI18nOptions = { locales?: Array<string | { code: string }> }
+
 export default defineNuxtConfig({
   modules: [
     resolve('./modules/config'),
@@ -77,14 +79,14 @@ export default defineNuxtConfig({
     'nitro:config'(nitroConfig) {
       const nuxt = useNuxt()
 
-      const i18nOptions = nuxt.options.i18n
+      const i18nOptions = (nuxt.options as typeof nuxt.options & { i18n?: DocusI18nOptions }).i18n
 
       const routes: string[] = []
       if (!i18nOptions) {
         routes.push('/')
       }
       else {
-        routes.push(...(i18nOptions.locales?.map(locale => typeof locale === 'string' ? `/${locale}` : `/${locale.code}`) || []))
+        routes.push(...(i18nOptions.locales?.map((locale: string | { code: string }) => typeof locale === 'string' ? `/${locale}` : `/${locale.code}`) || []))
       }
 
       nitroConfig.prerender = nitroConfig.prerender || {}

--- a/layer/server/routes/sitemap.xml.ts
+++ b/layer/server/routes/sitemap.xml.ts
@@ -27,11 +27,11 @@ export default defineEventHandler(async (event) => {
 
   for (const collection of collections) {
     try {
-      const pages = await queryCollection(event, collection as 'docs').all()
+      const pages = await (queryCollection as unknown as (event: unknown, collection: string) => { all: () => Promise<Array<Record<string, unknown> & { path?: string }>> })(event, collection).all()
 
       for (const page of pages) {
-        const meta = page as unknown as Record<string, unknown>
-        const pagePath = (page.path as string) || '/'
+        const meta = page as Record<string, unknown>
+        const pagePath = page.path || '/'
 
         // Skip pages with sitemap: false in frontmatter
         if (meta.sitemap === false) continue


### PR DESCRIPTION
Closes #1299

## Summary

This fixes `nuxt typecheck` for consumer apps that use `extends: ['docus']` and enable the same Docus feature surface exercised by a real app.

The verified scope is still narrow:
- package-internal type cleanup only
- no runtime behavior changes
- no attempt to solve broader Docus layer/embed issues

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [docus-1299](https://stackblitz.com/github/onmax/repros/tree/repro/docus-1299/docus-1299?startScript=typecheck) | `nuxt typecheck` fails |
| Fix | [docus-1299-fix](https://stackblitz.com/github/onmax/repros/tree/repro/docus-1299/docus-1299-fix?startScript=typecheck) | `nuxt typecheck` succeeds |

Both repros now mirror the packaged-consumer failure more closely:
- they extend Docus
- define a small `assistant` app config
- enable the same Nuxt/Docus feature surface that exposed the remaining consumer-package errors

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/docus-1299 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set docus-1299
cd docus-1299 && pnpm i && pnpm typecheck
```

## Verify Fix

```bash
cd .. && git sparse-checkout set docus-1299 docus-1299-fix
cd docus-1299-fix && pnpm i && pnpm typecheck
```

The `-fix` folder uses [pnpm patch](https://pnpm.io/cli/patch) to apply the fix locally.

## Real App Verification

I also verified this patch against the Nimiq developer center by consuming the forked package branch directly, with no local `pnpm patch` entry:

- dependency: `github:onmax/docus#dist/typecheck-consumer-app`
- `pnpm install` succeeds
- `pnpm typecheck` succeeds
- `pnpm build` succeeds

## Related

- [#1282](https://github.com/nuxt-content/docus/issues/1282) shows separate route/injection issues when embedding Docus under `/docs`
- [#1290](https://github.com/nuxt-content/docus/issues/1290) shows separate dependency/setup friction around layer usage

This PR only addresses the consumer `nuxt typecheck` failures reproduced in [#1299](https://github.com/nuxt-content/docus/issues/1299).
