### PR TITLE
fix(mcp): use request fetch for raw page content

### DIFF
--- a/layer/server/mcp/tools/get-page.ts
+++ b/layer/server/mcp/tools/get-page.ts
@@ -41,9 +41,7 @@ WORKFLOW: This tool returns the complete page content including title, descripti
         return errorResult('Page not found')
       }
 
-      const content = await $fetch<string>(`/raw${path}.md`, {
-        baseURL: siteUrl,
-      })
+      const content = await event.$fetch<string>(`/raw${path}.md`)
 
       return jsonResult({
         title: page.title,


### PR DESCRIPTION
Follow-up to [#1302](https://github.com/nuxt-content/docus/pull/1302).

## Summary

`get-page` now derives its `url` from the incoming request origin, which is correct for proxied and deployed environments. The remaining problem is that it still fetches its markdown body through an absolute self-request.

That works locally, but on Cloudflare Workers the same-worker subrequest returns `404`, so `list-pages` works while `get-page` fails with `Failed to get page`.

This keeps the request-origin URL behavior but switches the content fetch to `event.$fetch('/raw${path}.md')`, which resolves through Nitro's request-bound fetch path instead of an outbound absolute request. That preserves the existing raw markdown response shape and avoids reconstructing markdown from parsed content data.

## Reproduction

| Variant | Source | Deployed worker | Result |
| --- | --- | --- | --- |
| Bug | [onmax/repros/docus-mcp-get-page-worker-repro](https://github.com/onmax/repros/tree/repro/docus-mcp-get-page-worker-repro/docus-mcp-get-page-worker-repro) | [docus-mcp-get-page-repro.je-cf9.workers.dev](https://docus-mcp-get-page-repro.je-cf9.workers.dev) | `get-page` returns `Failed to get page` |
| Fix | [onmax/repros/docus-mcp-get-page-worker-repro-fix](https://github.com/onmax/repros/tree/repro/docus-mcp-get-page-worker-repro/docus-mcp-get-page-worker-repro-fix) | [docus-mcp-get-page-repro-fix.je-cf9.workers.dev](https://docus-mcp-get-page-repro-fix.je-cf9.workers.dev) | `get-page` returns the raw markdown content |

## Verify

Broken worker:

```bash
curl -sS \
  -H 'accept: application/json, text/event-stream' \
  -H 'content-type: application/json' \
  -X POST https://docus-mcp-get-page-repro.je-cf9.workers.dev/mcp \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get-page","arguments":{"path":"/test"}}}'
```

Fixed worker:

```bash
curl -sS \
  -H 'accept: application/json, text/event-stream' \
  -H 'content-type: application/json' \
  -X POST https://docus-mcp-get-page-repro-fix.je-cf9.workers.dev/mcp \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get-page","arguments":{"path":"/test"}}}'
```

Local source verification:

```bash
pnpm typecheck
```
