### PR TITLE
fix(i18n): unify AI naming and shorten "Explain with AI" label for Polish locale

### DIFF
--- a/layer/i18n/locales/pl.json
+++ b/layer/i18n/locales/pl.json
@@ -34,7 +34,7 @@
     "copyWordmarkFailed": "Nie udało się skopiować wordmarku"
   },
   "assistant": {
-    "title": "Zapytaj SI",
+    "title": "Zapytaj AI",
     "placeholder": "Zadaj pytanie...",
     "tooltip": "Zadaj AI pytanie",
     "tryAsking": "Spróbuj zadać pytanie",
@@ -49,7 +49,7 @@
     "faq": "Często zadawane pytania",
     "chatCleared": "Czat został wyczyszczony po odświeżeniu",
     "lineBreak": "Podział wiersza",
-    "explainWithAi": "Wyjaśnij za pomocą sztucznej inteligencji",
+    "explainWithAi": "Wyjaśnij z AI",
     "toolListPages": "Wymienione strony dokumentacji",
     "toolReadPage": "Czytaj",
     "loading": {


### PR DESCRIPTION
## Changes
- unified AI terminology across the UI (`SI` → `AI`)
- shortened the "Explain with AI" label in Polish to improve readability

The previous label was unnecessarily long and caused UI overflow/truncation issues.

Before:

<img width="298" height="440" alt="image" src="https://github.com/user-attachments/assets/2559ffe8-8f82-4d78-8098-3247f52249bd" />



After:

<img width="338" height="345" alt="image" src="https://github.com/user-attachments/assets/97095f70-9674-4e33-9fd8-ae57a532399a" />
