### PR TITLE
fix(layer): he correct value of page metadata

### DIFF
--- a/layer/server/routes/sitemap.xml.ts
+++ b/layer/server/routes/sitemap.xml.ts
@@ -33,7 +33,7 @@ export default defineEventHandler(async (event) => {
       ) => { all: () => Promise<Array<Record<string, unknown> & { path?: string }>> })(event, collection).all()
 
       for (const page of pages) {
-        const meta = page as Record<string, unknown>
+        const meta = page.meta as Record<string, unknown>
         const pagePath = page.path || '/'
 
         // Skip pages with sitemap: false in frontmatter


### PR DESCRIPTION
Fixed a bug where sitemap settings were not being applied correctly, caused by an incorrect value assignment in the configuration.