### PR TITLE
fix(css): resolve `app.config.ts` source to an absolute path

### DIFF
--- a/layer/modules/css.ts
+++ b/layer/modules/css.ts
@@ -14,6 +14,7 @@ export default defineNuxtModule({
     const resolver = createResolver(import.meta.url)
 
     const contentDir = resolve(nuxt.options.rootDir, 'content')
+    const appConfigPath = resolve(nuxt.options.srcDir, 'app.config.ts')
     const uiPath = resolveModulePath('@nuxt/ui', { from: import.meta.url, conditions: ['style'] })
     const tailwindPath = resolveModulePath('tailwindcss', { from: import.meta.url, conditions: ['style'] })
     const layerDir = resolver.resolve('../app')
@@ -34,13 +35,14 @@ export default defineNuxtModule({
 
     const cssTemplate = addTemplate({
       filename: 'docus.css',
+      write: true,
       getContents: () => {
         return `@import ${JSON.stringify(tailwindPath)};
 @import ${JSON.stringify(uiPath)};
 
 @source "${contentDir.replace(/\\/g, '/')}/**/*";
 @source "${layerDir.replace(/\\/g, '/')}/**/*";
-@source "../../app.config.ts";
+@source "${appConfigPath.replace(/\\/g, '/')}";
 @source "${assistantDir.replace(/\\/g, '/')}/**/*";
 
 html.dark .shiki span {


### PR DESCRIPTION
Resolves https://github.com/nuxt-content/docus/issues/1403
Resolves https://github.com/nuxt-content/docus/issues/1399

## Problem

In `layer/modules/css.ts`, the generated `docus.css` declared:

```css
@source "../../app.config.ts";
```

This was the **only relative path** among the CSS sources — every other `@source`/`@import` is an absolute filesystem path. Tailwind resolves `@source` relative to the CSS file that contains it, and that file is generated at `<srcDir>/.nuxt/docus.css`. So `../../app.config.ts` resolved to `<rootDir>/app.config.ts` — a file that **does not exist**.

For example, in this repo the generated `docs/.nuxt/docus.css` contained:

```css
@source "/…/docus/docs/content/**/*";
@source "/…/docus/layer/app/**/*";
@source "../../app.config.ts";   ← resolves to /…/docus/app.config.ts (missing)
@source "/…/docus/layer/modules/assistant/**/*";
```

The real config lives at `<srcDir>/app.config.ts` (e.g. `docs/app/app.config.ts`). As a result, class names declared in the user's `app.config.ts` (UI theme overrides) were never whitelisted by Tailwind and could get purged.

## Fix

Compute an absolute path from `nuxt.options.srcDir`, consistent with the other sources:

```ts
const appConfigPath = resolve(nuxt.options.srcDir, 'app.config.ts')
// …
@source "${appConfigPath.replace(/\\/g, '/')}";
```

This now points at the user's actual `app.config.ts` (the same `srcDir` the `app.css` import is derived from).

> Note: the layer's own `app.config.ts` (`layer/app/app.config.ts`) is already covered by the `@source "${layerDir}/**/*"` glob, so this line only ever needed to target the user's config.

This may also resolve related class-purging issues seen in [nuxt-studio](https://github.com/nuxt-content/nuxt-studio).