### PR TITLE
fix(docs): make local docs scripts work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "pnpm run docs:dev",
-    "docs:dev": "cd docs && cross-env TMPDIR=/tmp nuxt dev --extends ../layer",
-    "docs:build": "nuxt build docs --extends ../layer",
+    "docs:dev": "nuxt prepare layer && cd docs && cross-env TMPDIR=/tmp nuxt dev --extends ../layer",
+    "docs:build": "nuxt prepare layer && nuxt build docs --extends ../layer",
     "dev:prepare": "nuxt prepare layer && nuxt prepare docs --extends ../layer && nuxt prepare playground --extends ../layer",
     "playground:dev": "cd playground && nuxt dev --extends ../layer",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "pnpm run docs:dev",
-    "docs:dev": "cd docs && TMPDIR=/tmp nuxt dev --extends ../layer",
+    "docs:dev": "cd docs && cross-env TMPDIR=/tmp nuxt dev --extends ../layer",
     "docs:build": "nuxt build docs --extends ../layer",
     "dev:prepare": "nuxt prepare layer && nuxt prepare docs --extends ../layer && nuxt prepare playground --extends ../layer",
     "playground:dev": "cd playground && nuxt dev --extends ../layer",
@@ -27,6 +27,7 @@
     "@nuxt/eslint-config": "^1.16.0",
     "@release-it/bumper": "^7.0.6",
     "@release-it/conventional-changelog": "^11.0.1",
+    "cross-env": "^10.1.0",
     "eslint": "^10.5.0",
     "nuxt": "4.4.8",
     "release-it": "^20.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@release-it/conventional-changelog':
         specifier: ^11.0.1
         version: 11.0.1(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.4.0)(release-it@20.2.0(@types/node@26.0.0)(magicast@0.5.3))
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       eslint:
         specifier: ^10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -507,6 +510,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@es-joy/jsdoccomment@0.87.0':
     resolution: {integrity: sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==}
@@ -4721,6 +4727,11 @@ packages:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
     engines: {node: '>=18.0'}
 
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -8931,6 +8942,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@es-joy/jsdoccomment@0.87.0':
     dependencies:
       '@types/estree': 1.0.9
@@ -13001,6 +13014,11 @@ snapshots:
       readable-stream: 4.7.0
 
   croner@10.0.1: {}
+
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:


### PR DESCRIPTION
## Summary

This fixes the local docs dev flow on Windows.

The root `docs:dev` script previously used POSIX-style inline environment syntax:

```sh
TMPDIR=/tmp nuxt dev --extends ../layer
```

That works in Unix shells, but fails on Windows because `cmd.exe` treats `TMPDIR=/tmp` as a command. This PR switches that part to `cross-env` so the existing `TMPDIR=/tmp` workaround is preserved while making the script portable to Windows.

The docs scripts also now run `nuxt prepare layer` before starting or building the docs app. Without that, a fresh checkout can start the dev server but fail on first request because Vite tries to read generated layer TypeScript config files from `layer/.nuxt`, which does not exist yet.

## Context

I’ve seen similar package-script issues in other Nuxt repositories too. I think it is worth using one script pattern that works across operating systems so contributors on Windows, macOS, and Linux can all run the same commands without shell-specific workarounds.

This was tested on Windows. The changes use standard package-script tooling and existing Nuxt commands, but I’m relying on maintainers/CI to confirm the behavior on macOS and Linux.

## System info

|                      |                                                              |
| -------------------- | ------------------------------------------------------------ |
| **Operating system** | `Windows 10.0.26200`                                         |
| **CPU**              | `AMD Ryzen 5 7600 6-Core Processor               (12 cores)` |
| **Node.js version**  | `v24.13.1`                                                   |
| **nuxt/cli version** | `3.36.1`                                                     |
| **Package manager**  | `pnpm@11.8.0`                                                |
| **Nuxt version**     | `4.4.8`                                                      |
| **Nitro version**    | `2.13.4`                                                     |
| **Builder**          | `vite@7.3.3`                                                 |
| **Config**           | `-`                                                          |
| **Modules**          | `-`                                                          |
