### PR TITLE
fix(docs): correct mdc code fences in components page

### DIFF
--- a/docs/content/en/3.essentials/3.components.md
+++ b/docs/content/en/3.essentials/3.components.md
@@ -44,7 +44,7 @@ Use the `accordion` and `accordion-item` components to display an [Accordion](ht
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::accordion
 
   :::accordion-item{label="What is Docus and what are its key features??" icon="i-lucide-circle-help"}
@@ -59,7 +59,7 @@ Use the `accordion` and `accordion-item` components to display an [Accordion](ht
   [Nuxt UI](https://ui.nuxt.com/) is a collection of premium Vue components, composables and utils.
   :::
   ::
-  ```
+```
   :::
 ::
 
@@ -75,11 +75,11 @@ Use markdown in the default slot of the `badge` component to display a [Badge](h
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::badge
   **v3.0.0**
   ::
-  ```
+```
   :::
 ::
 
@@ -113,7 +113,7 @@ You can also use the `note`, `tip`, `warning` and `caution` shortcuts with pre-d
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::note
   Here's some additional information.
   ::
@@ -129,7 +129,7 @@ You can also use the `note`, `tip`, `warning` and `caution` shortcuts with pre-d
   ::caution
   This action cannot be undone.
   ::
-  ```
+```
   :::
 ::
 
@@ -187,7 +187,7 @@ Wrap your `card` components with the `card-group` component to group them togeth
   :::
 
   :::tabs-item{.my-5 icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   :::card-group
 
   ::card
@@ -231,7 +231,7 @@ Wrap your `card` components with the `card-group` component to group them togeth
   ::
 
   :::
-  ```
+```
   :::
 ::
 
@@ -251,7 +251,7 @@ Wrap your content with the `collapsible` component to display a [Collapsible](ht
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::collapsible
 
   | Prop    | Default   | Type                     |
@@ -261,7 +261,7 @@ Wrap your content with the `collapsible` component to display a [Collapsible](ht
   | `color` | `neutral` | `string`{lang="ts-type"} |
 
   ::
-  ```
+```
   :::
 ::
 
@@ -291,7 +291,7 @@ A `field`is a prop or parameter to display in your content. You can group them b
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::field-group
     ::field{name="analytics" type="boolean"}
       Default to `false` - Enables analytics for your project (coming soon).
@@ -309,7 +309,7 @@ A `field`is a prop or parameter to display in your content. You can group them b
     Default to `false` - Enables SQL database to store your application's data.
   ::
   ::
-  ```
+```
   :::
 ::
 
@@ -402,7 +402,7 @@ Use the `level` prop to define which heading will be used for the steps.
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ````mdc
+````mdc
   ::steps{level="4"}
     #### Start a fresh new project
     
@@ -416,6 +416,6 @@ Use the `level` prop to define which heading will be used for the steps.
     docus dev
     ```
   ::
-  ````
+````
   :::
 ::

--- a/docs/content/fr/3.essentials/3.components.md
+++ b/docs/content/fr/3.essentials/3.components.md
@@ -44,7 +44,7 @@ Utilisez les composants `accordion` et `accordion-item` pour afficher un [Accord
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::accordion
 
   :::accordion-item{label="Qu'est-ce que Docus et quelles sont ses fonctionnalités clés ?" icon="i-lucide-circle-help"}
@@ -59,7 +59,7 @@ Utilisez les composants `accordion` et `accordion-item` pour afficher un [Accord
   Nuxt UI est une collection de composants Vue premium, de composables et d'utilitaires construits sur [Nuxt UI](https://ui.nuxt.com/). Nuxt UI est gratuit en développement, mais nécessite une licence pour la production.
   :::
   ::
-  ```
+```
   :::
 ::
 
@@ -75,11 +75,11 @@ Utilisez du markdown dans le slot par défaut du composant `badge` pour afficher
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::badge
   **v3.0.0**
   ::
-  ```
+```
   :::
 ::
 
@@ -113,7 +113,7 @@ Vous pouvez également utiliser les raccourcis `note`, `tip`, `warning` et `caut
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::note
   Voici des informations supplémentaires.
   ::
@@ -129,7 +129,7 @@ Vous pouvez également utiliser les raccourcis `note`, `tip`, `warning` et `caut
   ::caution
   Cette action est irréversible.
   ::
-  ```
+```
   :::
 ::
 
@@ -187,7 +187,7 @@ Regroupez vos composants `card` avec le composant `card-group` pour les afficher
   :::
 
   :::tabs-item{.my-5 icon="i-lucide-eye" label="Aperçu"}
-  ```mdc
+```mdc
   :::card-group
 
   ::card
@@ -231,7 +231,7 @@ Regroupez vos composants `card` avec le composant `card-group` pour les afficher
   ::
 
   :::
-  ```
+```
   :::
 ::
 
@@ -251,7 +251,7 @@ Enveloppez votre contenu avec le composant `collapsible` pour afficher un [Colla
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::collapsible
 
   | Prop    | Défaut    | Type                     |
@@ -261,7 +261,7 @@ Enveloppez votre contenu avec le composant `collapsible` pour afficher un [Colla
   | `color` | `neutral` | `string`{lang="ts-type"} |
 
   ::
-  ```
+```
   :::
 ::
 
@@ -291,7 +291,7 @@ Un `field` est une prop ou un paramètre à afficher dans votre contenu. Vous po
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ```mdc
+```mdc
   ::field-group
     ::field{name="analytics" type="boolean"}
       Par défaut à `false` - Active l'analytics pour votre projet (bientôt disponible).
@@ -309,7 +309,7 @@ Un `field` est une prop ou un paramètre à afficher dans votre contenu. Vous po
     Par défaut à `false` - Active la base de données SQL pour stocker les données de votre application.
   ::
   ::
-  ```
+```
   :::
 ::
 
@@ -402,7 +402,7 @@ Utilisez la prop `level` pour définir quel titre sera utilisé pour les étapes
   :::
 
   :::tabs-item{icon="i-lucide-code" label="Code"}
-  ````mdc
+````mdc
   ::steps{level="4"}
     #### Démarrer un nouveau projet
     
@@ -416,6 +416,6 @@ Utilisez la prop `level` pour définir quel titre sera utilisé pour les étapes
     docus dev
     ```
   ::
-  ````
+````
   :::
 ::


### PR DESCRIPTION
Fixes the Markdown Components page at https://docus.dev/en/essentials/components.

Some component examples on this page include MDC syntax inside code tabs. In the current page, that structure can cause later sections to be treated as part of the preceding tab content, which means large parts of the page are no longer rendered as regular documentation sections.

This PR restores the expected page structure so each component section is rendered independently.