### PR TITLE
fix(layer): emit absolute sitemap URLs from configured site.url

### DIFF
--- a/layer/modules/config.ts
+++ b/layer/modules/config.ts
@@ -60,6 +60,14 @@ export default defineNuxtModule({
     })
 
     /*
+    ** Site URL (expose to the server: /sitemap.xml needs it at runtime)
+    */
+    nuxt.options.runtimeConfig.public.site = defu(
+      nuxt.options.runtimeConfig.public.site as { url?: string } | undefined,
+      { url: (typeof nuxt.options.site === 'object' && nuxt.options.site?.url) || url },
+    )
+
+    /*
     ** MCP route (expose to client so the page header dropdown stays in sync
     ** with the user-configured `mcp.route` from @nuxtjs/mcp-toolkit)
     */

--- a/layer/server/routes/sitemap.xml.ts
+++ b/layer/server/routes/sitemap.xml.ts
@@ -1,4 +1,5 @@
 import { queryCollection } from '@nuxt/content/server'
+import { withoutTrailingSlash } from 'ufo'
 import { inferSiteURL } from '../../utils/meta'
 import { getAvailableLocales, getCollectionsToQuery, isNavigationPath } from '../utils/content'
 
@@ -9,7 +10,11 @@ interface SitemapUrl {
 
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig(event)
-  const siteUrl = inferSiteURL() || ''
+  // Config first: inferSiteURL() only reads env vars, so a configured
+  // site.url would be dropped and every <loc> emitted relative.
+  const siteUrl = withoutTrailingSlash(
+    (config.public.site as { url?: string } | undefined)?.url || inferSiteURL() || '',
+  )
 
   const availableLocales = getAvailableLocales(config.public as Record<string, unknown>)
   const collections = getCollectionsToQuery(undefined, availableLocales)


### PR DESCRIPTION
## Problem

`/sitemap.xml` gets its base URL from `inferSiteURL()`, which only reads env vars. A `site.url` set in `nuxt.config` is ignored, so it falls back to `''` and every entry comes out relative:

```xml
<loc>/docs/getting-started/introduction</loc>
```

The sitemap spec requires absolute URLs, so search engines reject these. Nothing warns at build time.

## Reproduction

Set `site: { url: 'https://example.com' }` in `nuxt.config`, no env vars, then `nuxt build` and fetch `/sitemap.xml`.

## Fix

Expose the resolved `site.url` on `runtimeConfig.public.site`, the same way `mcp.route` is already exposed, and read it in the route. `inferSiteURL()` stays as the fallback so env-var deploys are unaffected.

## Verified

| Setup | Result |
|---|---|
| `site.url` in config | absolute URLs |
| env var only | unchanged |
| trailing slash in url | no double slash |

`pnpm lint` and `pnpm typecheck` pass.

## Note

`pnpm install` fails on a clean checkout: `packageManager` pins `pnpm@11.13.0`, which shipped a broken binary. Not related to this PR, happy to file separately.