### PR TITLE
feat(modules): agentic 404 to answer agents

### DIFF
--- a/docs/content/en/4.ai/4.llms.md
+++ b/docs/content/en/4.ai/4.llms.md
@@ -39,6 +39,49 @@ export default defineNuxtConfig({
 })
 ```
 
+## Agent-friendly 404s
+
+Instead of replying with a JSON error body, Docus replies with a short markdown document, listing the machine-readable entry points your site actually serves:
+
+```bash
+curl -H "Accept: text/markdown" https://docus.dev/en/does-not-exist
+```
+
+```md
+# 404 — Page not found
+
+`/en/does-not-exist` was not found on this site.
+
+## Where to look next
+
+- [/llms.txt](/llms.txt): index of Docus
+- [/llms-full.txt](/llms-full.txt): the full content of this site as a single markdown document
+- [/sitemap.xml](/sitemap.xml): every page, with its last modification date
+- [/.well-known/skills/index.json](/.well-known/skills/index.json): agent skills published by this site
+- [/](/): home page
+```
+
+The skills entry only appears when your site [publishes skills](/en/ai/skills), and `/llms-full.txt` only when it is enabled, so the document never points at a route that does not exist.
+
+The response keeps the `404` status and is served as `text/markdown; charset=utf-8` with `Vary: Accept`, so CDNs never mix it up with the HTML variant.
+
+Only clients that clearly aren't rendering HTML get this document. Untouched:
+
+- **Browsers**: any request accepting `text/html` still renders the theme error page
+- **API clients**: requests accepting `application/json`, or targeting `/api/**` and `*.json`, keep the default JSON error body
+- **`fetch()` and `$fetch`**: browser-initiated requests keep the default JSON error body, so `error.data` stays parseable
+- **Assets**: a missing script, style, image or feed keeps the default error body, since markdown would be meaningless there
+
+To restore the default error body:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  docus: {
+    notFound: false,
+  },
+})
+```
+
 ## Raw Markdown Access
 
 When `nuxt-llms` is enabled, Docus also exposes a raw markdown endpoint so AI agents can fetch LLM-ready source files without going through the full rendering pipeline. This reduces token usage and improves response speed for AI-powered tools consuming your documentation.

--- a/docs/content/fr/4.ai/4.llms.md
+++ b/docs/content/fr/4.ai/4.llms.md
@@ -39,6 +39,49 @@ export default defineNuxtConfig({
 })
 ```
 
+## 404 adaptées aux agents
+
+Plutôt que de répondre avec un corps d'erreur JSON, Docus renvoie un court document markdown qui liste les points d'entrée exploitables par une machine réellement servis par votre site :
+
+```bash
+curl -H "Accept: text/markdown" https://docus.dev/fr/page-inexistante
+```
+
+```md
+# 404 — Page not found
+
+`/fr/page-inexistante` was not found on this site.
+
+## Where to look next
+
+- [/llms.txt](/llms.txt): index of Docus
+- [/llms-full.txt](/llms-full.txt): the full content of this site as a single markdown document
+- [/sitemap.xml](/sitemap.xml): every page, with its last modification date
+- [/.well-known/skills/index.json](/.well-known/skills/index.json): agent skills published by this site
+- [/](/): home page
+```
+
+L'entrée des skills n'apparaît que si votre site [publie des skills](/fr/ai/skills), et `/llms-full.txt` uniquement si le fichier est activé : le document ne pointe donc jamais vers une route inexistante.
+
+La réponse conserve le statut `404` et est servie en `text/markdown; charset=utf-8` avec `Vary: Accept`, afin que les CDN ne confondent jamais les deux variantes.
+
+Seuls les clients qui n'affichent manifestement pas de HTML reçoivent ce document. Ne sont pas affectés :
+
+- **Les navigateurs** : toute requête acceptant `text/html` affiche toujours la page d'erreur du thème
+- **Les clients d'API** : les requêtes acceptant `application/json`, ou visant `/api/**` et `*.json`, conservent le corps d'erreur JSON par défaut
+- **`fetch()` et `$fetch`** : les requêtes initiées par le navigateur conservent le corps d'erreur JSON, pour que `error.data` reste exploitable
+- **Les assets** : un script, style, image ou flux manquant conserve le corps d'erreur par défaut, le markdown n'y aurait aucun sens
+
+Pour rétablir le corps d'erreur par défaut :
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  docus: {
+    notFound: false,
+  },
+})
+```
+
 ## Accès au Markdown brut
 
 Lorsque `nuxt-llms` est activé, Docus expose également un endpoint markdown brut permettant aux agents IA de récupérer les fichiers source prêts pour les LLMs sans passer par le pipeline de rendu complet. Cela réduit l'utilisation de tokens et améliore la vitesse de réponse pour les outils IA consommant votre documentation.

--- a/layer/index.d.ts
+++ b/layer/index.d.ts
@@ -4,6 +4,7 @@ import type { SkillsModuleOptions } from './modules/skills'
 export interface DocusNuxtConfig {
   assistant?: AssistantModuleOptions
   skills?: SkillsModuleOptions
+  notFound?: boolean
 }
 
 declare module '@nuxt/schema' {

--- a/layer/modules/not-found/index.ts
+++ b/layer/modules/not-found/index.ts
@@ -1,0 +1,67 @@
+import { createResolver, defineNuxtModule } from '@nuxt/kit'
+import type { Nuxt } from '@nuxt/schema'
+import type { NitroConfig } from 'nitropack'
+import type { NotFoundLink } from './runtime/server/utils/not-found'
+
+type DocusLlmsOptions = { domain?: string, title?: string, full?: unknown }
+type DocusSkillsRuntimeConfig = { catalog?: Array<{ name: string }> }
+
+/**
+ * Answer agent 404s with markdown instead of Nitro's JSON error body.
+ *
+ * Only the links this site actually serves are advertised.
+ */
+export default defineNuxtModule({
+  meta: {
+    name: 'not-found',
+  },
+  setup(_inlineOptions, nuxt) {
+    if (nuxt.options.docus?.notFound === false) return
+
+    const { resolve } = createResolver(import.meta.url)
+
+    nuxt.hook('modules:done', () => {
+      nuxt.options.runtimeConfig.notFound = { links: buildLinks(nuxt) }
+    })
+
+    const onNitroConfig = nuxt.hook as (name: 'nitro:config', cb: (nitroConfig: NitroConfig) => void) => void
+    onNitroConfig('nitro:config', (nitroConfig) => {
+      const existing = nitroConfig.errorHandler
+      const handlers = Array.isArray(existing) ? existing : existing ? [existing] : []
+
+      nitroConfig.errorHandler = [resolve('./runtime/server/utils/errors'), ...handlers]
+    })
+  },
+})
+
+function buildLinks(nuxt: Nuxt): NotFoundLink[] {
+  const llms = nuxt.options.llms as DocusLlmsOptions | undefined
+  const skills = nuxt.options.runtimeConfig.skills as DocusSkillsRuntimeConfig | undefined
+  const title = llms?.title || 'this documentation'
+
+  const links: NotFoundLink[] = []
+
+  if (llms?.domain) {
+    links.push({ path: '/llms.txt', description: `index of ${title}` })
+
+    if (llms.full) {
+      links.push({
+        path: '/llms-full.txt',
+        description: 'the full content of this site as a single markdown document',
+      })
+    }
+  }
+
+  links.push({ path: '/sitemap.xml', description: 'every page, with its last modification date' })
+
+  if (skills?.catalog?.length) {
+    links.push({
+      path: '/.well-known/skills/index.json',
+      description: 'agent skills published by this site',
+    })
+  }
+
+  links.push({ path: '/', description: 'home page' })
+
+  return links
+}

--- a/layer/modules/not-found/runtime/server/utils/errors.ts
+++ b/layer/modules/not-found/runtime/server/utils/errors.ts
@@ -1,0 +1,48 @@
+import { appendResponseHeader, send, setResponseHeader, setResponseStatus } from 'h3'
+import type { NitroErrorHandler } from 'nitropack/types'
+import { buildNotFoundMarkdown, requestPath, wantsAsset, wantsHtml, wantsJson } from './not-found'
+import type { NotFoundLink } from './not-found'
+import { useRuntimeConfig } from '#imports'
+
+interface NotFoundRuntimeConfig {
+  links?: NotFoundLink[]
+}
+
+/**
+ * Answer agent 404s with markdown pointing at the site's machine-readable
+ * entry points, instead of Nitro's JSON error body.
+ */
+const notFoundMarkdownHandler: NitroErrorHandler = async (error, event, { defaultHandler }) => {
+  if (event.handled) return
+  if ((error.statusCode || 500) !== 404) return
+  if (wantsHtml(event) || wantsJson(event) || wantsAsset(event)) return
+
+  const config = useRuntimeConfig(event)
+
+  // Fall back to the default handler, which will return a JSON error body.
+  const fallback = await defaultHandler(error, event, { json: true })
+  if (fallback.status === 302) return
+
+  const baseURL = config.app?.baseURL || '/'
+  const { links } = (config.notFound || {}) as NotFoundRuntimeConfig
+
+  // Keep a route's own status text ("Article not found"), which beats "Not Found".
+  setResponseStatus(event, 404, error.statusMessage || 'Not Found')
+  setResponseHeader(event, 'content-type', 'text/markdown; charset=utf-8')
+  setResponseHeader(event, 'cache-control', 'no-cache')
+  setResponseHeader(event, 'x-content-type-options', 'nosniff')
+  // Append the `Accept` header to the `Vary` header, so CDNs don't mix up the markdown and HTML variants.
+  appendResponseHeader(event, 'vary', 'Accept')
+
+  return send(
+    event,
+    buildNotFoundMarkdown({
+      path: requestPath(event, baseURL),
+      baseURL,
+      links,
+      message: error.message,
+    }),
+  )
+}
+
+export default notFoundMarkdownHandler

--- a/layer/modules/not-found/runtime/server/utils/not-found.ts
+++ b/layer/modules/not-found/runtime/server/utils/not-found.ts
@@ -1,0 +1,116 @@
+import { getRequestHeader } from 'h3'
+import type { H3Event } from 'h3'
+
+/** Cap on echoed values: the path is attacker-controlled and an agent reads the body. */
+const MAX_ECHO_LENGTH = 200
+
+/** Compared after dropping the `: /path` suffix Nitro appends in development. */
+const GENERIC_MESSAGES = new Set(['', 'not found', 'page not found'])
+
+function accepts(event: H3Event, type: string): boolean {
+  const header = getRequestHeader(event, 'accept')
+  return !!header && header.toLowerCase().includes(type)
+}
+
+function readHeader(event: H3Event, name: string): string {
+  return (getRequestHeader(event, name) || '').toLowerCase()
+}
+
+function pathname(event: H3Event): string {
+  return (event.path || '/').split('?')[0] || '/'
+}
+
+/** Nitro strips the base from `event.path`; restore it so the body agrees with its links. */
+export function requestPath(event: H3Event, baseURL = '/'): string {
+  return `${baseURL.replace(/\/$/, '')}${pathname(event)}`
+}
+
+/** Browsers keep the theme's error page. */
+export function wantsHtml(event: H3Event): boolean {
+  return accepts(event, 'text/html')
+}
+
+/**
+ * API clients keep the default JSON body.
+ */
+export function wantsJson(event: H3Event): boolean {
+  if (accepts(event, 'application/json')) return true
+  if (readHeader(event, 'sec-fetch-mode') === 'cors' && readHeader(event, 'sec-fetch-dest') === 'empty') {
+    return true
+  }
+
+  const path = pathname(event)
+  return path.startsWith('/api/') || path.endsWith('.json')
+}
+
+/**
+ * Only page-ish requests get a document: a missing script, image or feed is
+ * consumed by code, and markdown would be nonsense there. `.md` stays in,
+ * since a raw markdown URL is exactly what an agent asks for.
+ */
+export function wantsAsset(event: H3Event): boolean {
+  const extension = pathname(event).split('/').pop()?.match(/\.([a-z0-9]+)$/i)?.[1]
+  return !!extension && !['md', 'html', 'htm'].includes(extension.toLowerCase())
+}
+
+/** Drop what would break out of the surrounding code span, then cap the length. */
+function escapeEcho(value: string): string {
+  let cleaned = ''
+  for (const char of value) {
+    const code = char.codePointAt(0) ?? 0
+    if (code < 0x20 || code === 0x7F || char === '`') continue
+    cleaned += char
+  }
+  cleaned = cleaned.trim()
+  return cleaned.length > MAX_ECHO_LENGTH ? `${cleaned.slice(0, MAX_ECHO_LENGTH)}…` : cleaned
+}
+
+/** A route's own 404 message ("No article with that slug") says more than the path missing. */
+export function specificMessage(message?: string): string | undefined {
+  const value = escapeEcho(message || '')
+  if (!value) return undefined
+  const normalized = value.toLowerCase().replace(/:.*$/, '').trim()
+  return GENERIC_MESSAGES.has(normalized) ? undefined : value
+}
+
+export interface NotFoundLink {
+  /** Root-relative path, without `app.baseURL`. */
+  path: string
+  description: string
+}
+
+export interface NotFoundMarkdownOptions {
+  /** Requested path, already base-prefixed. */
+  path: string
+  /** `app.baseURL`, so links resolve on sub-path deployments. */
+  baseURL?: string
+  /** Resources this site actually serves, resolved at build time. */
+  links?: NotFoundLink[]
+  /** The error's own message, when it says more than "404". */
+  message?: string
+}
+
+export function buildNotFoundMarkdown(options: NotFoundMarkdownOptions): string {
+  const base = (options.baseURL || '/').replace(/\/$/, '')
+
+  const lines = [
+    '# 404 — Page not found',
+    '',
+    `\`${escapeEcho(options.path)}\` was not found on this site.`,
+  ]
+
+  const message = specificMessage(options.message)
+  if (message) {
+    lines.push('', `> ${message}`)
+  }
+
+  const links = options.links || []
+  if (links.length) {
+    lines.push('', '## Where to look next', '')
+    for (const link of links) {
+      lines.push(`- [${base}${link.path}](${base}${link.path}): ${link.description}`)
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -11,6 +11,7 @@ export default defineNuxtConfig({
     resolve('./modules/routing'),
     resolve('./modules/markdown-rewrite'),
     resolve('./modules/skills'),
+    resolve('./modules/not-found'),
     resolve('./modules/css'),
     () => {
       const nuxt = useNuxt()


### PR DESCRIPTION
## Summary

Answer agent 404s with a markdown document listing the site's machine-readable entry points, instead of  JSON error body. Comes from an [Is Agentic](https://is-agentic.com) scan of docus.dev, which flagged the JSON 404 as a dead end for crawlers.

```md
# 404 — Page not found

`/wrongpath` was not found on this site.

## Where to look next

- [/llms.txt](/llms.txt): index of Docus
- [/llms-full.txt](/llms-full.txt): the full content of this site as a single markdown document
- [/sitemap.xml](/sitemap.xml): every page, with its last modification date
- [/.well-known/skills/index.json](/.well-known/skills/index.json): agent skills published by this site
- [/](/): home page
```

## Changes

**New module** (`layer/modules/not-found/`)

Prepends a Nitro error handler that only answers page-ish 404s. 

Browsers (text/html), API clients (application/json, /api/**, *.json), $fetch (sec-fetch-mode: cors) and assets keep the default error body. Response keeps its 404 status, plus Vary: Accept so CDNs don't mix the variants.

Links are resolved at build time so the document never points at a route the site doesn't serve: `/llms-full.txt` only when enabled, `/.well-known/skills/index.json` only when skills exist. 

Opt out with `docus.notFound: false`.