### PR TITLE
fix(assistant): pass value prop to Comark 0.6

### DIFF
--- a/docs/app/components/content/AssistantDemo.vue
+++ b/docs/app/components/content/AssistantDemo.vue
@@ -115,7 +115,7 @@ function resetChat() {
             >
               <AssistantComark
                 v-if="isTextUIPart(part) && part.text"
-                :markdown="part.text"
+                :value="part.text"
               />
 
               <UChatTool

--- a/layer/modules/assistant/runtime/components/AssistantPanel.vue
+++ b/layer/modules/assistant/runtime/components/AssistantPanel.vue
@@ -216,7 +216,7 @@ defineShortcuts({
               chevron="leading"
             >
               <AssistantComark
-                :markdown="part.text"
+                :value="part.text"
                 :streaming="isPartStreaming(part)"
               />
             </UChatReasoning>
@@ -224,7 +224,7 @@ defineShortcuts({
             <template v-else-if="isTextUIPart(part) && part.text.length > 0">
               <AssistantComark
                 v-if="message.role === 'assistant'"
-                :markdown="part.text"
+                :value="part.text"
                 :streaming="isPartStreaming(part)"
               />
               <p


### PR DESCRIPTION
## Summary

`@comark/vue` 0.6 removed the `markdown` prop. `AssistantComark` is created with `defineMarkdownComponent` (0.6 API) and only reads `value`.

`AssistantPanel` still passed `:markdown="part.text"`, so the assistant streamed tool chips but never rendered the final answer.

## Changes

- `AssistantPanel.vue`: `:markdown` → `:value` (reasoning + assistant text)
- `docs/.../AssistantDemo.vue`: same binding

## Test plan

- [ ] Open Ask AI, ask a question that uses MCP tools
- [ ] Confirm tool chips **and** the streamed markdown answer both render
- [ ] Confirm no stream/runtime errors in the console