### PR TITLE
fix(i18n): support hyphenated locale codes

### DIFF
--- a/layer/app/app.vue
+++ b/layer/app/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ContentNavigationItem, PageCollections } from '@nuxt/content'
 import * as nuxtUiLocales from '@nuxt/ui/locale'
+import { getLocaleKey } from '../utils/locale'
 import { transformNavigation } from './utils/navigation'
 import { useDocusShortcuts } from './composables/useDocusShortcuts'
 import { useSubNavigation } from './composables/useSubNavigation'
@@ -12,10 +13,10 @@ const site = useSiteConfig()
 const { locale, locales, isEnabled, switchLocalePath } = useDocusI18n()
 const { isEnabled: isAssistantEnabled } = useAssistant()
 
-const nuxtUiLocale = computed(() => nuxtUiLocales[locale.value as keyof typeof nuxtUiLocales] || nuxtUiLocales.en)
+const nuxtUiLocale = computed(() => nuxtUiLocales[getLocaleKey(locale.value) as keyof typeof nuxtUiLocales] || nuxtUiLocales.en)
 const lang = computed(() => nuxtUiLocale.value.code)
 const dir = computed(() => nuxtUiLocale.value.dir)
-const collectionName = computed(() => isEnabled.value ? `docs_${locale.value}` : 'docs')
+const collectionName = computed(() => isEnabled.value ? `docs_${getLocaleKey(locale.value)}` : 'docs')
 
 useHead({
   meta: [

--- a/layer/app/components/app/AppSearch.vue
+++ b/layer/app/components/app/AppSearch.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ContentNavigationItem, PageCollections } from '@nuxt/content'
+import { getLocaleKey } from '../../../utils/locale'
 
 const props = defineProps<{
   navigation?: ContentNavigationItem[]
@@ -9,7 +10,7 @@ const appConfig = useAppConfig()
 const { forced: forcedColorMode } = useDocusColorMode()
 const { locale, isEnabled } = useDocusI18n()
 
-const collectionName = computed(() => (isEnabled.value ? `docs_${locale.value}` : 'docs') as keyof PageCollections)
+const collectionName = computed(() => (isEnabled.value ? `docs_${getLocaleKey(locale.value)}` : 'docs') as keyof PageCollections)
 const useFts = appConfig.search.fts
 
 const { data: files } = useFts

--- a/layer/app/error.vue
+++ b/layer/app/error.vue
@@ -2,6 +2,7 @@
 import type { NuxtError } from '#app'
 import type { ContentNavigationItem, PageCollections } from '@nuxt/content'
 import * as nuxtUiLocales from '@nuxt/ui/locale'
+import { getLocaleKey } from '../utils/locale'
 import { transformNavigation } from './utils/navigation'
 
 const props = defineProps<{
@@ -10,7 +11,7 @@ const props = defineProps<{
 
 const { locale, locales, isEnabled, t, switchLocalePath } = useDocusI18n()
 
-const nuxtUiLocale = computed(() => nuxtUiLocales[locale.value as keyof typeof nuxtUiLocales] || nuxtUiLocales.en)
+const nuxtUiLocale = computed(() => nuxtUiLocales[getLocaleKey(locale.value) as keyof typeof nuxtUiLocales] || nuxtUiLocales.en)
 const lang = computed(() => nuxtUiLocale.value.code)
 const dir = computed(() => nuxtUiLocale.value.dir)
 
@@ -45,7 +46,7 @@ if (isEnabled.value) {
   })
 }
 
-const collectionName = computed(() => isEnabled.value ? `docs_${locale.value}` : 'docs')
+const collectionName = computed(() => isEnabled.value ? `docs_${getLocaleKey(locale.value)}` : 'docs')
 
 const { data: navigation } = await useAsyncData(`navigation_${collectionName.value}`, () => queryCollectionNavigation(collectionName.value as keyof PageCollections), {
   transform: (data: ContentNavigationItem[]) => transformNavigation(data, isEnabled.value, locale.value),

--- a/layer/app/pages/[[lang]]/[...slug].vue
+++ b/layer/app/pages/[[lang]]/[...slug].vue
@@ -2,6 +2,7 @@
 import { kebabCase } from 'scule'
 import type { ContentNavigationItem, Collections, DocsCollectionItem } from '@nuxt/content'
 import { findPageHeadline } from '@nuxt/content/utils'
+import { getLocaleKey } from '../../../utils/locale'
 
 definePageMeta({
   layout: 'docs',
@@ -12,7 +13,7 @@ const { locale, isEnabled, t } = useDocusI18n()
 const { isOpen } = useAssistant()
 const appConfig = useAppConfig()
 const navigation = inject<Ref<ContentNavigationItem[]>>('navigation')
-const collectionName = computed(() => isEnabled.value ? `docs_${locale.value}` : 'docs')
+const collectionName = computed(() => isEnabled.value ? `docs_${getLocaleKey(locale.value)}` : 'docs')
 
 const [{ data: page }, { data: surround }] = await Promise.all([
   useAsyncData(kebabCase(route.path), () => queryCollection(collectionName.value as keyof Collections).path(route.path).first() as Promise<DocsCollectionItem>),

--- a/layer/app/plugins/i18n.ts
+++ b/layer/app/plugins/i18n.ts
@@ -1,5 +1,6 @@
 import type { RouteLocationNormalized } from 'vue-router'
 import { consola } from 'consola'
+import { findLocaleFile } from '../../utils/locale'
 
 const log = consola.withTag('docus')
 
@@ -19,9 +20,8 @@ export default defineNuxtPlugin(async () => {
     let locale = configuredLocale
     let resolvedMessages: Record<string, unknown>
 
-    // Try to load the requested locale file
-    const localeKey = `../../i18n/locales/${configuredLocale}.json`
-    const localeLoader = localeFiles[localeKey]
+    const fileName = findLocaleFile(configuredLocale, Object.keys(localeFiles).map(key => key.split('/').pop()!))
+    const localeLoader = fileName ? localeFiles[`../../i18n/locales/${fileName}`] : undefined
 
     if (localeLoader) {
       const localeModule = await localeLoader()

--- a/layer/app/templates/landing.vue
+++ b/layer/app/templates/landing.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import type { Collections } from '@nuxt/content'
+import { getLocaleKey } from '../../utils/locale'
 
 const route = useRoute()
 const { locale, isEnabled } = useDocusI18n()
 
 // Dynamic collection name based on i18n status
-const collectionName = computed(() => isEnabled.value ? `landing_${locale.value}` : 'landing')
+const collectionName = computed(() => isEnabled.value ? `landing_${getLocaleKey(locale.value)}` : 'landing')
 
 const { data: page } = await useAsyncData(collectionName.value, () => queryCollection(collectionName.value as keyof Collections).path(route.path).first())
 if (!page.value) {

--- a/layer/content.config.ts
+++ b/layer/content.config.ts
@@ -2,7 +2,8 @@ import type { DefinedCollection } from '@nuxt/content'
 import { defineContentConfig, defineCollection, z } from '@nuxt/content'
 import { useNuxt } from '@nuxt/kit'
 import { joinURL } from 'ufo'
-import { landingPageExists, docsFolderExists } from './utils/pages'
+import { landingPageExists, docsFolderExists, findLocaleFolder } from './utils/pages'
+import { getLocaleKey, normalizeLocale } from './utils/locale'
 
 const { options } = useNuxt()
 const cwd = joinURL(options.rootDir, 'content')
@@ -25,26 +26,28 @@ let collections: Record<string, DefinedCollection>
 if (locales && Array.isArray(locales)) {
   collections = {}
   for (const locale of locales) {
-    const code = (typeof locale === 'string' ? locale : locale.code).replace('-', '_')
-    const hasLocaleDocs = docsFolderExists(options.rootDir, code)
+    const code = normalizeLocale(typeof locale === 'string' ? locale : locale.code)
+    const collectionKey = getLocaleKey(code)
+    const dir = findLocaleFolder(options.rootDir, code) || code
+    const hasLocaleDocs = docsFolderExists(options.rootDir, dir)
 
     if (!hasLandingPage) {
-      collections[`landing_${code}`] = defineCollection({
+      collections[`landing_${collectionKey}`] = defineCollection({
         type: 'page',
         source: {
           cwd,
-          include: `${code}/index.md`,
+          include: `${dir}/index.md`,
         },
       })
     }
 
-    collections[`docs_${code}`] = defineCollection({
+    collections[`docs_${collectionKey}`] = defineCollection({
       type: 'page',
       source: {
         cwd,
-        include: hasLocaleDocs ? `${code}/docs/**` : `${code}/**/*`,
+        include: hasLocaleDocs ? `${dir}/docs/**` : `${dir}/**/*`,
         prefix: hasLocaleDocs ? `/${code}/docs` : `/${code}`,
-        exclude: [`${code}/index.md`],
+        exclude: [`${dir}/index.md`],
       },
       schema: createDocsSchema(),
     })

--- a/layer/modules/config.ts
+++ b/layer/modules/config.ts
@@ -1,18 +1,19 @@
 import { createResolver, defineNuxtModule, logger } from '@nuxt/kit'
 import { defu } from 'defu'
-import { existsSync } from 'node:fs'
-import { join } from 'node:path'
+import { readdirSync } from 'node:fs'
+import { findLocaleFile, normalizeLocale } from '../utils/locale'
+import { findLocaleFolder } from '../utils/pages'
 import { inferSiteURL, getPackageJsonMetadata } from '../utils/meta'
 import { getGitBranch, getGitEnv, getLocalGitInfo } from '../utils/git'
 
 const log = logger.withTag('docus')
 
-type I18nLocale = string | { code: string, name?: string }
-type DocusI18nOptions = { locales?: I18nLocale[], strategy?: string }
+type I18nLocale = string | { code: string, name?: string, language?: string }
+type DocusI18nOptions = { locales?: I18nLocale[], defaultLocale?: string, strategy?: string }
 type DocusMcpOptions = { route?: string, enabled?: boolean }
 type RegisterModuleOptions = {
   langDir: string
-  locales: Array<{ code: string, name: string, file: string }>
+  locales: Array<{ code: string, name: string, language: string, file: string }>
 }
 
 export default defineNuxtModule({
@@ -82,34 +83,59 @@ export default defineNuxtModule({
 
     if (i18nOptions && typeof i18nOptions === 'object' && i18nOptions.locales) {
       const { resolve } = createResolver(import.meta.url)
+      const langDir = resolve('../i18n/locales')
+      const localeFileNames = readdirSync(langDir)
+
+      // Keep the original tag as `language` for `html lang` and `hreflang`
+      const normalizeLocaleEntry = (locale: I18nLocale) => {
+        const code = typeof locale === 'string' ? locale : locale.code
+        const base = typeof locale === 'string' ? { name: code, language: code } : locale
+
+        return { ...base, code: normalizeLocale(code), language: base.language || code }
+      }
+
+      const normalizedLocales = i18nOptions.locales.map(normalizeLocaleEntry)
 
       // Filter locales to only include existing ones
-      const filteredLocales = i18nOptions.locales.filter((locale: I18nLocale) => {
-        const localeCode = typeof locale === 'string' ? locale : locale.code
+      const filteredLocales = normalizedLocales.filter((locale) => {
+        const localeCode = locale.code
 
         // Check for JSON locale file
-        const localeFilePath = resolve('../i18n/locales', `${localeCode}.json`)
-        const hasLocaleFile = existsSync(localeFilePath)
+        const localeFile = findLocaleFile(localeCode, localeFileNames)
 
         // Check for content folder
-        const contentPath = join(nuxt.options.rootDir, 'content', localeCode)
-        const hasContentFolder = existsSync(contentPath)
+        const contentFolder = findLocaleFolder(nuxt.options.rootDir, localeCode)
 
-        if (!hasLocaleFile) {
+        if (!localeFile) {
           log.warn(`Locale file not found: ${localeCode}.json - skipping locale "${localeCode}"`)
         }
 
-        if (!hasContentFolder) {
+        if (!contentFolder) {
           log.warn(`Content folder not found: content/${localeCode}/ - skipping locale "${localeCode}"`)
         }
 
-        return hasLocaleFile && hasContentFolder
+        return !!localeFile && !!contentFolder
       })
 
       // Override strategy to prefix
       typedNuxtOptions.i18n = {
         ...i18nOptions,
+        locales: normalizedLocales,
+        defaultLocale: i18nOptions.defaultLocale && normalizeLocale(i18nOptions.defaultLocale),
         strategy: 'prefix',
+      }
+
+      // @nuxtjs/i18n reads locales from each layer config, not from the merged options
+      for (const layer of nuxt.options._layers) {
+        const layerI18n = (layer.config as { i18n?: DocusI18nOptions }).i18n
+
+        if (layerI18n?.locales) {
+          layerI18n.locales = layerI18n.locales.map(normalizeLocaleEntry)
+
+          if (layerI18n.defaultLocale) {
+            layerI18n.defaultLocale = normalizeLocale(layerI18n.defaultLocale)
+          }
+        }
       }
 
       // Expose filtered locales
@@ -120,20 +146,12 @@ export default defineNuxtModule({
       const registerI18nModule = nuxt.hook as unknown as (name: string, callback: (register: (options: RegisterModuleOptions) => void) => void) => void
 
       registerI18nModule('i18n:registerModule', (register) => {
-        const langDir = resolve('../i18n/locales')
+        const locales = filteredLocales.flatMap((locale) => {
+          const file = findLocaleFile(locale.code, localeFileNames)
 
-        const locales = filteredLocales.map((locale: I18nLocale) => {
-          return typeof locale === 'string'
-            ? {
-                code: locale,
-                name: locale,
-                file: `${locale}.json`,
-              }
-            : {
-                code: locale.code,
-                name: locale.name || locale.code,
-                file: `${locale.code}.json`,
-              }
+          return file
+            ? [{ code: locale.code, name: locale.name || locale.code, language: locale.language, file }]
+            : []
         })
 
         register({

--- a/layer/server/mcp/tools/list-pages.ts
+++ b/layer/server/mcp/tools/list-pages.ts
@@ -3,7 +3,7 @@ import { queryCollection } from '@nuxt/content/server'
 import { joinURL } from 'ufo'
 import { z } from 'zod'
 import { inferSiteURL } from '../../../utils/meta'
-import { getAvailableLocales, getCollectionsToQuery } from '../../utils/content'
+import { getAvailableLocales, getCollectionsToQuery, getLocaleFromCollection } from '../../utils/content'
 
 export default defineMcpTool({
   description: `Lists all available documentation pages with their categories and basic information.
@@ -60,7 +60,7 @@ OUTPUT: Returns a structured list with:
             title: page.title,
             path: page.path,
             description: page.description,
-            locale: collectionName.replace('docs_', ''),
+            locale: getLocaleFromCollection(collectionName, availableLocales),
             url: siteUrl ? joinURL(siteUrl, baseURL, page.path) : joinURL(baseURL, page.path),
           }))
         }),

--- a/layer/server/routes/sitemap.xml.ts
+++ b/layer/server/routes/sitemap.xml.ts
@@ -1,5 +1,6 @@
 import { queryCollection } from '@nuxt/content/server'
 import { inferSiteURL } from '../../utils/meta'
+import { getLocaleKey } from '../../utils/locale'
 import { getAvailableLocales, getCollectionsToQuery, isNavigationPath } from '../utils/content'
 
 interface SitemapUrl {
@@ -16,7 +17,7 @@ export default defineEventHandler(async (event) => {
 
   if (availableLocales.length > 0) {
     for (const locale of availableLocales) {
-      collections.push(`landing_${locale}`)
+      collections.push(`landing_${getLocaleKey(locale)}`)
     }
   }
   else {

--- a/layer/server/utils/content.ts
+++ b/layer/server/utils/content.ts
@@ -1,4 +1,5 @@
 import type { LocaleObject } from '@nuxtjs/i18n'
+import { getLocaleKey } from '../../utils/locale'
 
 type ConfigWithLocales = {
   i18n?: { locales?: Array<string | LocaleObject> }
@@ -17,11 +18,11 @@ export function getAvailableLocales(config: ConfigWithLocales): string[] {
 
 export function getCollectionsToQuery(locale: string | undefined, availableLocales: string[]): string[] {
   if (locale && availableLocales.includes(locale)) {
-    return [`docs_${locale}`]
+    return [`docs_${getLocaleKey(locale)}`]
   }
 
   return availableLocales.length > 0
-    ? availableLocales.map(l => `docs_${l}`)
+    ? availableLocales.map(l => `docs_${getLocaleKey(l)}`)
     : ['docs']
 }
 
@@ -34,8 +35,15 @@ export function getCollectionFromPath(path: string, availableLocales: string[]):
   const firstSegment = pathSegments[0]
 
   if (firstSegment && availableLocales.includes(firstSegment)) {
-    return `docs_${firstSegment}`
+    return `docs_${getLocaleKey(firstSegment)}`
   }
 
   return 'docs'
+}
+
+/** Maps a `docs_*` collection name back to the locale code it was built from. */
+export function getLocaleFromCollection(collectionName: string, availableLocales: string[]): string {
+  const key = collectionName.replace('docs_', '')
+
+  return availableLocales.find(locale => getLocaleKey(locale) === key) || key
 }

--- a/layer/utils/locale.ts
+++ b/layer/utils/locale.ts
@@ -1,0 +1,20 @@
+/**
+ * Nuxt Content lowercases every path it generates, so an uppercase code would
+ * never match its own pages. The original tag is kept as the locale `language`.
+ */
+export function normalizeLocale(code: string): string {
+  return code.toLowerCase()
+}
+
+/**
+ * Collection names must be valid identifiers, so hyphens become underscores.
+ * `@nuxt/ui/locale` export names use the same form.
+ */
+export function getLocaleKey(code: string): string {
+  return normalizeLocale(code).replace(/-/g, '_')
+}
+
+/** Locale files keep their BCP 47 name, so match them on the normalized code. */
+export function findLocaleFile(code: string, fileNames: string[]): string | undefined {
+  return fileNames.find(fileName => fileName.toLowerCase() === `${normalizeLocale(code)}.json`)
+}

--- a/layer/utils/pages.ts
+++ b/layer/utils/pages.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync } from 'node:fs'
 import { joinURL } from 'ufo'
 
 /**
@@ -19,4 +19,15 @@ export function docsFolderExists(rootDir: string, locale?: string): boolean {
     ? joinURL(rootDir, 'content', locale, 'docs')
     : joinURL(rootDir, 'content', 'docs')
   return existsSync(docsPath)
+}
+
+/**
+ * Finds the content folder for a locale, ignoring case so `content/zh-TW/` and
+ * `content/zh-tw/` both work. Returns the name as it is on disk.
+ */
+export function findLocaleFolder(rootDir: string, locale: string): string | undefined {
+  const contentDir = joinURL(rootDir, 'content')
+  if (!existsSync(contentDir)) return undefined
+
+  return readdirSync(contentDir).find(dir => dir.toLowerCase() === locale)
 }


### PR DESCRIPTION

Resolves #1233, resolves #1280.

Any locale whose code contains a hyphen — `zh-CN`, `zh-TW`, `pt-BR`, `en-GB`, `de-CH` — 404s on every route, and the build still exits 0. Docus ships `zh-CN.json`, `zh-TW.json` and `pt-BR.json`, so those locales look supported but have never worked.

## Why it happens

The collection *is* created, but it is **empty**:

```
docs_en          2 rows
docs_zh_CN       0 rows      <-- created, but nothing was ever inserted
```

One locale code is used for four things with conflicting constraints:

| Usage | Constraint | Needed for `zh-CN` |
|---|---|---|
| Collection name | must be a valid JS identifier — `resolveCollection()` rejects `-` and drops the collection | `docs_zh_cn` |
| Content folder / `include` glob | must match what is on disk | `content/zh-CN/` |
| Page path / URL prefix | Nuxt Content slugifies every segment with `lower: true` | `/zh-cn/...` |
| `html lang`, `hreflang` | canonical BCP 47 tag | `zh-CN` |

#1246 addressed only the first row. One code, four call sites, four spellings:

```ts
// content.config.ts — #1246 replaced the hyphen in the shared variable
const code = locale.code.replace('-', '_')            // 'zh_CN'
collections[`docs_${code}`] = defineCollection({      // 'docs_zh_CN'  valid
  source: {
    include: `${code}/**/*`,                          // 'zh_CN/**/*'  no such folder
    prefix: `/${code}`,                               // '/zh_CN'
  },
})

// modules/config.ts — no replace, so the locale filter looks elsewhere
existsSync(join(rootDir, 'content', locale.code))     // 'content/zh-CN'

// app.vue, error.vue, AppSearch.vue, landing.vue, [...slug].vue,
// server/utils/content.ts, sitemap.xml.ts — no replace either
`docs_${locale.value}`                                // 'docs_zh-CN'  no such collection

// app.vue, error.vue — @nuxt/ui export names are zh_cn / zh_tw
nuxtUiLocales[locale.value]                           // undefined -> English
```

Before #1246 the collection name was invalid and Nuxt Content warned about it; after #1246 the name is valid and the failure is silent. Both states 404.

<details>
<summary><b>Reproduction on <code>main</code> (v5.13.0)</b></summary>

```bash
pnpx create-docus i18n-test -t i18n
cd i18n-test
```

In `nuxt.config.ts`, replace `fr` with any hyphenated code:

```ts
i18n: {
  defaultLocale: 'en',
  locales: [
    { code: 'en', name: 'English' },
    { code: 'zh-CN', name: '简体中文' },
  ],
}
```

```bash
mv content/fr content/zh-CN
pnpm build && node .output/server/index.mjs
```

The build exits 0, but:

```
ERROR  [request error] [fatal] [GET] http://localhost/zh-CN
Page not found
  [cause]: { statusCode: 404, statusMessage: 'Page not found', fatal: true }

[nitro]   ├─ /zh-CN (214ms)
  │ └── [404] Page not found
```

`/en` returns 200, every `/zh-CN` route returns 404. Prerender 404s are non-fatal, which is why CI (`lint` + `typecheck` + `build`) stays green on a completely broken locale.

</details>

<details>
<summary><b>How people work around it today</b></summary>

Every workaround avoids the hyphen, at the cost of a non-standard locale code.

**Rename the bundled locale file** — suggested in #1280 ("it no longer conforms to geographic identifier codes such as `zh-cn`, `zh-tw`, `zh-hk`"):

```bash
mv i18n/locales/zh-CN.json i18n/locales/cn.json
mv content/zh-CN content/cn
```

**Use a bare language code.** This is what we ship today. It routes, but `@nuxt/ui/locale` has no `zh` export, so component strings stay English and `<html lang>` is wrong — and it needs a hook to undo Docus's own locale filter:

```ts
const locales = [
  { code: 'en', name: 'English' },
  { code: 'zh', name: '繁體中文', language: 'zh-Hant', file: 'zh.json' },
]

export default defineNuxtConfig({
  extends: ['docus'],
  modules: [
    '@nuxtjs/i18n',
    // Docus only keeps locales that have a bundled locale file, so `zh` is
    // dropped from `filteredLocales`, `locales.length > 1` is false and the
    // language switcher never renders. Put it back after modules are done.
    (_options, nuxt) => {
      nuxt.hook('modules:done', () => {
        const docus = nuxt.options.runtimeConfig.public.docus as {
          filteredLocales?: Array<{ code: string }>
        }
        const filtered = docus.filteredLocales ?? []

        docus.filteredLocales = [...filtered, ...locales.filter(locale =>
          !filtered.some(item => item.code === locale.code),
        )]
      })
    },
  ],
  i18n: { defaultLocale: 'en', locales },
})
```

`zh` cannot distinguish Simplified from Traditional, so sites needing both end up dropping one.

</details>

## The fix

Derive the two forms the code actually needs instead of overloading one variable — the same layering the rest of the ecosystem uses, where `@nuxt/ui` keeps `code: "zh-TW"` in its data and normalizes only its export names:

```ts
// layer/utils/locale.ts
normalizeLocale('zh-TW')   // 'zh-tw'  URL prefix, i18n code
getLocaleKey('zh-TW')      // 'zh_tw'  collection name, @nuxt/ui export name
```

- **Normalize codes to lowercase** in `modules/config.ts`, since Nuxt Content always generates lowercase page paths. The original tag is kept as the locale's `language`, so `<html lang>` and `hreflang` still emit `zh-TW`. `defaultLocale` is normalized the same way.
- **Look the content folder up on disk** rather than guessing its name, so `content/zh-TW/` and `content/zh-tw/` both resolve and `include` gets the real folder name — which is what #1246 broke.
- **Route every collection name through `getLocaleKey()`** — in `content.config.ts` and the nine runtime call sites that build one.
- **Fix the `@nuxt/ui` locale lookup**, which used the raw code and silently fell back to English.
- **Match bundled locale files case-insensitively**, so `zh-TW.json` serves the `zh-tw` locale, in both the i18n registration and the single-language plugin.

One part is less obvious: `@nuxtjs/i18n` collects its locales from **each layer's raw config**, not from the merged `nuxt.options.i18n`. Normalizing only the merged options registers a second, empty locale, so `modules/config.ts` normalizes the layer configs too.

Users keep writing standard BCP 47 codes, and name the content folder however they like:

```ts
i18n: {
  defaultLocale: 'en',
  locales: [
    { code: 'en', name: 'English' },
    { code: 'zh-TW', name: '繁體中文' },
  ],
}
```
### What is accepted, before and after

| `code` in `nuxt.config` | URL before | URL after |
|---|---|---|
| `en`, `fr`, `ja` | `/en` | `/en` — unchanged |
| `zh-TW`, `zh-CN`, `pt-BR`, `en-GB` | 404 on every route | `/zh-tw`, `/zh-cn`, `/pt-br`, `/en-gb` |
| `zh-tw` (already lowercase) | 404 on every route | `/zh-tw` |

| Content folder for `code: 'zh-TW'` | before | after |
|---|---|---|
| `content/zh-TW/` | not found | resolved |
| `content/zh-tw/` | not found | resolved |

| | before | after |
|---|---|---|
| `<html lang>` | `en` — `@nuxt/ui` lookup missed and fell back | `zh-TW` — the locale's `language` |
| `hreflang` | — | `zh-tw`, matching the URL |

## Breaking changes

None in practice.

- **Locales without a hyphen** (`en`, `fr`, `ja`, …) — every transform is a no-op. Verified by rebuilding the `en` + `fr` docs site: identical routes, no 404s.
- **Locales with a hyphen** — they 404 on every route today, so no working setup can regress, and no workaround relies on the current behavior. Existing `content/zh-CN/` folders keep working; the folder is matched case-insensitively rather than renamed.

<details>
<summary><b>Verification</b></summary>

A project with three locales (`en`, `zh-CN`, `zh-TW`), built on `main` and on this branch:

1. `pnpm build` — on `main` the prerender log shows `[404] Page not found` for `/zh-CN` and `/zh-TW`; on this branch it does not.
2. `node .output/server/index.mjs`, then open the locale routes:

   | Route | `main` | this branch |
   |---|---|---|
   | `/en`, `/en/getting-started/introduction` | 200 | 200 |
   | `/zh-cn`, `/zh-cn/getting-started/introduction` | 404 | 200 |
   | `/zh-tw`, `/zh-tw/getting-started/introduction` | 404 | 200 |

3. View source on a `zh-TW` page — `<html lang="zh-TW" dir="ltr">`, the canonical tag, not the lowercased URL code.
4. Docus UI strings come from the bundled `zh-CN.json` / `zh-TW.json`, and the Nuxt UI component strings from `@nuxt/ui/locale`'s `zh_cn` / `zh_tw`.
5. The language switcher lists all three locales, and its links, the sidebar and `sitemap.xml` all point at `/zh-cn/...` and `/zh-tw/...`.
6. Rebuilding the `en` + `fr` docs site gives identical routes and no 404s.
7. A locale with no bundled locale file still warns and is skipped, as before.

Content folders work in either case — `content/zh-TW/` and `content/zh-tw/` both resolve, on case-sensitive filesystems too.

`pnpm lint`, `pnpm typecheck` and `pnpm docs:build` all pass.

</details>

## Related

- [`enpitsuLin/docus-i18n-code`](https://github.com/enpitsuLin/docus-i18n-code) — the minimal reproduction published with #1233 (`pt-BR`).

Everything above is a proposal,  let me know if you would rather solve this differently. 😊
