### PR TITLE
fix(types): apply the AppConfig augmentation in apps extending the layer

### DIFF
--- a/layer/index.d.ts
+++ b/layer/index.d.ts
@@ -1,3 +1,9 @@
+// `app/types/index.d.ts` is a module, so its `declare module 'nuxt/schema'`
+// block is a module augmentation and only applies once something pulls the file
+// into the program. Nuxt adds this file to a consumer's `tsconfig` via a
+// `/// <reference path>`, so importing it from here is what makes the AppConfig
+// types reach apps extending the layer.
+import type {} from './app/types'
 import type { AssistantModuleOptions } from './modules/assistant'
 
 export interface DocusNuxtConfig {


### PR DESCRIPTION
## Summary

`layer/app/types/index.d.ts` has imports and exports, so it is a **module** — which makes its `declare module 'nuxt/schema'` block a *module augmentation*, and those only take effect once something pulls the file into the program. Inside this repo that happens (the layer is a local directory whose files are reachable), so `pnpm typecheck` is green. In an app that installs `docus` from npm, nothing imports or references it: the file is in the consumer's `tsconfig` `include`, and `tsc --listFilesOnly` even lists it, but the augmentation never applies.

Every `AppConfig` field declared in that file is therefore silently missing in consumers, and the app falls back to the shapes generated from `nuxt.schema.ts`. It's easy to miss because the fallback types are *almost* right — until one of them isn't.

Since 5.13.0 it isn't. `useSeo` reads `AppConfig['seo']['schema']` (added in #1433), and only `app/types/index.d.ts` declares `schema`, so `nuxi typecheck` now fails in every app extending the layer:

```
node_modules/docus/app/composables/useSeo.ts(37,53): error TS2339: Property 'schema'
does not exist on type '{ title?: string | undefined; description?: string | undefined; }'
node_modules/docus/app/composables/useSeo.ts(139,41): error TS2339: Property 'schema'
does not exist on type '{ title?: string | undefined; description?: string | undefined; }'
```

That type is the one generated from `layer/nuxt.schema.ts`, where `seo` is just `title` + `description`.

## Fix

`index.d.ts` is already reachable in consumers — Nuxt writes `/// <reference path="../node_modules/docus/index.d.ts" />` into `.nuxt/nuxt.d.ts` — so importing the types file from there is enough:

```ts
import type {} from './app/types'
```

One line, no type changes, nothing new shipped (`app` and `index.d.ts` are both already in `files`).

## Reproduction

A minimal app is enough — no fixture repo needed:

```bash
cd layer && npm pack                 # docus-5.13.0.tgz
mkdir repro && cd repro
# package.json depending on ../docus-5.13.0.tgz + nuxt + vue-tsc + better-sqlite3
# nuxt.config.ts: export default defineNuxtConfig({ extends: ['docus'] })
# tsconfig.json: { "extends": "./.nuxt/tsconfig.json" }
# content/index.md with any front matter
npm install && npx nuxt typecheck
```

Before: the two `useSeo.ts` errors above. After: gone.

To confirm the mechanism rather than the symptom, add a marker to the augmentation:

```ts
declare module 'nuxt/schema' {
  interface AppConfig {
    zzTest: 'yes'
    // …
```

and probe it from the app. On `main` `AppConfig['zzTest']` resolves to `unknown` (it falls through `AppConfig`'s index signature — the augmentation is inert). With this patch it resolves.

## Verified

- `pnpm lint` — unchanged (0 errors, the pre-existing `vue/no-v-html` warning)
- `pnpm typecheck` — passes
- Minimal consumer app against a packed build of this branch — both `useSeo.ts` errors gone

## Out of scope

- **#1249 / #1347 (`github: false` rejected)** is a different mechanism, not fixed here: that error comes from `AppConfigInput`, which `defineAppConfig` checks against and which is fed by the generated `nuxt.schema.ts` types, not by the `AppConfig` augmentation. Worth a separate fix — either allowing `false` in `nuxt.schema.ts` or augmenting `AppConfigInput`.
- Four other errors a consumer still sees, all pre-existing and unrelated to this file (part of what #1413 reports): `useSeo.ts:172/221` (unhead `ResolvableArray` for the link/script arrays) and `plugins/i18n.ts:52` + `useAssistant.ts:59` (`i18n.defaultLocale` on `{}`).

Nothing in CI would catch a regression of this, since `pnpm typecheck` only checks the layer in-repo, where the augmentation does apply. A `nuxt typecheck` over a small app extending a packed layer would — happy to add one if you want it in this PR.
