### PR TITLE
feat(seo): use `nuxt-schema-org` and `useCanonical`

### DIFF
--- a/docs/content/en/2.concepts/3.configuration.md
+++ b/docs/content/en/2.concepts/3.configuration.md
@@ -71,10 +71,10 @@ For more details on front-matter, see the edition guide.
 
 ### Structured data
 
-Docus emits [JSON-LD](https://json-ld.org) on every page: 
+Docus emits [JSON-LD](https://json-ld.org) with [`nuxt-schema-org`](https://nuxtseo.com/docs/schema-org): 
 
-- `Article` and `BreadcrumbList` on documentation pages
-- `WebSite` on the landing page. 
+- `WebSite` and `WebPage` on every page
+- `TechArticle` and `BreadcrumbList` on documentation pages
 
 Search engines and AI agents read it to tell what a page is without parsing your markup.
 
@@ -110,11 +110,11 @@ export default defineAppConfig({
 | `operatingSystem` | Platforms it runs on, defaults to `Web`. Only for `SoftwareApplication`. |
 | `price` | Price of the application. Set `0` to advertise it as free. Only for `SoftwareApplication` and `Product`. |
 | `priceCurrency` | ISO 4217 currency for `price`, defaults to `USD`. |
-| `organization` | Publisher of the site, emitted as a linked `Organization`. Accepts `name`, `url`, `logo`, `sameAs`. |
-| `organization.parentOrganization` | The company the publisher belongs to, emitted as a second linked `Organization`. |
+| `organization` | Publisher of the site, emitted as a linked `Organization`. Accepts `name`, `url`, `logo`, `sameAs`, `address` and `contactPoint`. |
+| `organization.parentOrganization` | The company the publisher belongs to, nested inside the publisher `Organization`. |
 
 ::note
-Nodes are linked through `@id`, so `publisher` always points at a single entity even when a parent organization is declared. Leave `seo.schema` out and the landing page keeps a plain `WebSite` node.
+Every `schemaOrg` option of the module is available in your `nuxt.config.ts`. Leave `seo.schema` out and the landing page keeps its `WebSite` and `WebPage` nodes.
 ::
 
 ### **Social sharing (OG) image**

--- a/docs/content/fr/2.concepts/3.configuration.md
+++ b/docs/content/fr/2.concepts/3.configuration.md
@@ -71,10 +71,10 @@ Pour plus de détails sur le frontmatter, consultez le guide d'édition.
 
 ### Données structurées
 
-Docus génère du [JSON-LD](https://json-ld.org) sur chaque page :
+Docus génère du [JSON-LD](https://json-ld.org) avec [`nuxt-schema-org`](https://nuxtseo.com/docs/schema-org) :
 
-- `Article` et `BreadcrumbList` sur les pages de documentation
-- `WebSite` sur la page d'accueil.
+- `WebSite` et `WebPage` sur chaque page
+- `TechArticle` et `BreadcrumbList` sur les pages de documentation
 
 Les moteurs de recherche et les agents IA s'appuient dessus pour identifier une page sans analyser votre balisage.
 
@@ -110,11 +110,11 @@ export default defineAppConfig({
 | `operatingSystem` | Plateformes sur lesquelles elle fonctionne, `Web` par défaut. Uniquement pour `SoftwareApplication`. |
 | `price` | Prix de l'application. Mettez `0` pour indiquer qu'elle est gratuite. Uniquement pour `SoftwareApplication` et `Product`. |
 | `priceCurrency` | Devise ISO 4217 pour `price`, `USD` par défaut. |
-| `organization` | Éditeur du site, généré comme `Organization` liée. Accepte `name`, `url`, `logo`, `sameAs`. |
-| `organization.parentOrganization` | L'entreprise à laquelle appartient l'éditeur, générée comme seconde `Organization` liée. |
+| `organization` | Éditeur du site, généré comme `Organization` liée. Accepte `name`, `url`, `logo`, `sameAs`, `address` et `contactPoint`. |
+| `organization.parentOrganization` | L'entreprise à laquelle appartient l'éditeur, imbriquée dans l'`Organization` de l'éditeur. |
 
 ::note
-Les nœuds sont liés par `@id`, donc `publisher` désigne toujours une seule entité, même lorsqu'une organisation parente est déclarée. Sans `seo.schema`, la page d'accueil conserve un simple nœud `WebSite`.
+Toutes les options `schemaOrg` du module sont disponibles dans votre `nuxt.config.ts`. Sans `seo.schema`, la page d'accueil conserve ses nœuds `WebSite` et `WebPage`.
 ::
 
 ### **Image de partage social (OG)**

--- a/layer/app/composables/useSeo.ts
+++ b/layer/app/composables/useSeo.ts
@@ -36,102 +36,64 @@ export interface UseSeoOptions {
 
 type SeoSchemaConfig = NonNullable<AppConfig['seo']['schema']>
 
+type SoftwareAppInput = NonNullable<Parameters<typeof defineSoftwareApp>[0]>
+
 type SeoOrganizationConfig = NonNullable<SeoSchemaConfig['organization']>
 
 /**
- * `contactPoint` and `address` are intentionally not derived: they can only come
- * from real business data, so a site has to provide them itself.
+ * The site publisher and, when it belongs to a larger company, its parent
+ * nested inside it. `contactPoint` and `address` are passed through as
+ * configured: they can only come from real business data, so a site has to
+ * provide them itself.
  */
-function buildOrganizationNode(organization: SeoOrganizationConfig, id: string, baseUrl: string) {
-  const node: Record<string, unknown> = {
-    '@type': 'Organization',
-    '@id': id,
-    'name': organization.name,
-    'url': organization.url || baseUrl,
-  }
+function organizationNode(organization: SeoOrganizationConfig | undefined) {
+  if (!organization?.name) return undefined
 
-  if (organization.logo) {
-    node.logo = organization.logo.startsWith('http') ? organization.logo : joinURL(baseUrl, organization.logo)
-  }
+  const { parentOrganization, ...publisher } = organization
 
-  if (organization.sameAs?.length) {
-    node.sameAs = organization.sameAs
-  }
-
-  return node
-}
-
-/**
- * `Organization` nodes for the site publisher and, when the publisher belongs to
- * a larger company, its parent. Both are linked so the graph has no orphan node,
- * and `publisher` keeps pointing at a single entity.
- */
-function buildOrganizationSchemas(schema: SeoSchemaConfig | undefined, baseUrl: string) {
-  const organization = schema?.organization
-  if (!organization?.name) return []
-
-  const publisher = buildOrganizationNode(organization, `${baseUrl}/#organization`, baseUrl)
-  const nodes = [publisher]
-
-  const parent = organization.parentOrganization
-  if (parent?.name) {
-    const parentId = `${baseUrl}/#parent-organization`
-    publisher.parentOrganization = { '@id': parentId }
-    nodes.push(buildOrganizationNode(parent, parentId, baseUrl))
-  }
-
-  return nodes
+  return defineOrganization({
+    ...publisher,
+    ...(parentOrganization?.name ? { parentOrganization: { '@type': 'Organization', ...parentOrganization } } : {}),
+  })
 }
 
 /** The node that answers "what is this site?": a product, a company, a person. */
-function buildIdentitySchema(
-  schema: SeoSchemaConfig | undefined,
-  context: { baseUrl: string, name: string | undefined, description: string | undefined, organizationId?: string },
-) {
-  const type = schema?.type
-  if (!type || !context.name) return undefined
-
-  // The publisher Organization is already emitted as its own node.
-  if (type === 'Organization' && schema?.organization?.name) return undefined
-
-  const node: Record<string, unknown> = {
-    '@type': type,
-    '@id': `${context.baseUrl}/#identity`,
-    'name': context.name,
-    'description': context.description,
-    'url': context.baseUrl,
+function identityNode(schema: SeoSchemaConfig | undefined, name: string, description: string | undefined) {
+  const shared = {
+    name,
+    description,
+    ...(schema?.sameAs?.length ? { sameAs: schema.sameAs } : {}),
   }
+  const offers = typeof schema?.price === 'number'
+    ? { offers: { price: schema.price, priceCurrency: schema.priceCurrency || 'USD' } }
+    : {}
 
-  if (schema?.sameAs?.length) {
-    node.sameAs = schema.sameAs
+  switch (schema?.type) {
+    case 'SoftwareApplication':
+      return defineSoftwareApp({
+        ...shared,
+        applicationCategory: (schema.applicationCategory || 'DeveloperApplication') as SoftwareAppInput['applicationCategory'],
+        operatingSystem: schema.operatingSystem || 'Web',
+        ...offers,
+      })
+    case 'Product':
+      return defineProduct({ ...shared, ...offers })
+    case 'Person':
+      return definePerson(shared)
+    case 'Organization':
+      // The publisher Organization is already emitted as its own node
+      return schema.organization?.name ? undefined : defineOrganization(shared)
+    default:
+      return undefined
   }
-
-  if (type === 'SoftwareApplication') {
-    node.applicationCategory = schema?.applicationCategory || 'DeveloperApplication'
-    node.operatingSystem = schema?.operatingSystem || 'Web'
-  }
-
-  if (typeof schema?.price === 'number' && (type === 'SoftwareApplication' || type === 'Product')) {
-    node.offers = {
-      '@type': 'Offer',
-      'price': schema.price,
-      'priceCurrency': schema.priceCurrency || 'USD',
-    }
-  }
-
-  if (context.organizationId && type !== 'Person') {
-    node.publisher = { '@id': context.organizationId }
-  }
-
-  return node
 }
 
 /**
  * Composable for comprehensive SEO setup including:
  * - Meta tags (title, description, og:*, twitter:*)
- * - Canonical URLs
+ * - Canonical and markdown alternate links, through `nuxt-agent-discovery`
  * - Hreflang tags for i18n
- * - JSON-LD structured data
+ * - JSON-LD structured data, through `nuxt-schema-org`
  */
 export function useSeo(options: UseSeoOptions) {
   const route = useRoute()
@@ -147,14 +109,9 @@ export function useSeo(options: UseSeoOptions) {
   const modifiedAt = computed(() => toValue(options.modifiedAt))
   const breadcrumbs = computed(() => toValue(options.breadcrumbs))
 
-  // Build canonical URL
-  const canonicalUrl = computed(() => {
-    if (!site.url) return undefined
-    return joinURL(site.url, route.path)
-  })
-
   // Base URL for building other URLs
   const baseUrl = computed(() => site.url ? withoutTrailingSlash(site.url) : '')
+  const canonicalUrl = computed(() => baseUrl.value ? joinURL(baseUrl.value, route.path) : undefined)
 
   // Set meta tags
   useSeoMeta({
@@ -167,20 +124,14 @@ export function useSeo(options: UseSeoOptions) {
     ogLocale: computed(() => isI18nEnabled.value ? locale.value : undefined),
   })
 
-  // Set canonical link
+  // Canonical link, plus the markdown twin as an alternate representation
+  useCanonical(() => route.path === '/' ? '/index.md' : `${route.path}.md`)
+
+  // Hreflang tags for i18n
   useHead({
     link: computed(() => {
       const links: Array<{ rel: string, href?: string, hreflang?: string }> = []
 
-      // Canonical URL
-      if (canonicalUrl.value) {
-        links.push({
-          rel: 'canonical',
-          href: canonicalUrl.value,
-        })
-      }
-
-      // Hreflang tags for i18n
       if (isI18nEnabled.value && baseUrl.value) {
         for (const loc of locales) {
           const localePath = switchLocalePath(loc.code)
@@ -217,109 +168,31 @@ export function useSeo(options: UseSeoOptions) {
   }
 
   // JSON-LD structured data
-  useHead({
-    script: computed(() => {
-      const scripts: Array<{ type: string, innerHTML: string }> = []
-
-      if (!baseUrl.value || !title.value) return scripts
-
-      const pageUrl = joinURL(baseUrl.value, route.path)
-
-      // Article schema for documentation pages
-      if (type.value === 'article') {
-        const articleSchema: Record<string, unknown> = {
-          '@context': 'https://schema.org',
-          '@type': 'Article',
-          'headline': title.value,
-          'description': description.value,
-          'url': pageUrl,
-          'mainEntityOfPage': {
-            '@type': 'WebPage',
-            '@id': pageUrl,
-          },
-        }
-
-        if (publishedAt.value) {
-          articleSchema.datePublished = publishedAt.value
-        }
-
-        if (modifiedAt.value) {
-          articleSchema.dateModified = modifiedAt.value
-        }
-
-        if (site.name) {
-          articleSchema.publisher = {
-            '@type': 'Organization',
-            'name': site.name,
-          }
-        }
-
-        scripts.push({
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify(articleSchema),
-        })
-      }
-
-      // WebSite schema for landing pages, plus the site identity when configured
-      if (type.value === 'website') {
-        const websiteSchema: Record<string, unknown> = {
-          '@type': 'WebSite',
-          '@id': `${baseUrl.value}/#website`,
-          'name': site.name || title.value,
-          'description': description.value,
-          'url': baseUrl.value,
-        }
-
-        const graph: Record<string, unknown>[] = [websiteSchema]
-
-        // The first node is the publisher; any other is a company it belongs to.
-        const organizationSchemas = buildOrganizationSchemas(seoSchema, baseUrl.value)
-        const publisherId = organizationSchemas[0]?.['@id'] as string | undefined
-        if (organizationSchemas.length) {
-          graph.push(...organizationSchemas)
-          websiteSchema.publisher = { '@id': publisherId }
-        }
-
-        const identitySchema = buildIdentitySchema(seoSchema, {
-          baseUrl: baseUrl.value,
-          name: site.name || title.value,
-          description: description.value,
-          organizationId: publisherId,
-        })
-        if (identitySchema) {
-          graph.push(identitySchema)
-          websiteSchema.about = { '@id': identitySchema['@id'] }
-        }
-
-        scripts.push({
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify({
-            '@context': 'https://schema.org',
-            '@graph': graph,
-          }),
-        })
-      }
-
-      // BreadcrumbList schema for navigation
-      if (breadcrumbs.value && breadcrumbs.value.length > 0) {
-        const breadcrumbSchema = {
-          '@context': 'https://schema.org',
-          '@type': 'BreadcrumbList',
-          'itemListElement': breadcrumbs.value.map((item, index) => ({
-            '@type': 'ListItem',
-            'position': index + 1,
-            'name': item.title,
-            'item': joinURL(baseUrl.value, item.path),
-          })),
-        }
-
-        scripts.push({
-          type: 'application/ld+json',
-          innerHTML: JSON.stringify(breadcrumbSchema),
-        })
-      }
-
-      return scripts
-    }),
-  })
+  if (type.value === 'article') {
+    useSchemaOrg([
+      defineArticle({
+        '@type': 'TechArticle',
+        'headline': title,
+        'description': description,
+        'datePublished': publishedAt,
+        'dateModified': modifiedAt,
+      }),
+      defineBreadcrumb({
+        itemListElement: () => (breadcrumbs.value || []).map(item => ({
+          name: item.title,
+          item: item.path,
+        })),
+      }),
+    ])
+  }
+  else {
+    const name = site.name || title.value
+    useSchemaOrg([
+      defineWebSite({
+        name,
+        description,
+      }),
+      ...[organizationNode(seoSchema?.organization), name ? identityNode(seoSchema, name, description.value) : undefined].filter(Boolean),
+    ])
+  }
 }

--- a/layer/app/composables/useSeo.ts
+++ b/layer/app/composables/useSeo.ts
@@ -124,8 +124,11 @@ export function useSeo(options: UseSeoOptions) {
     ogLocale: computed(() => isI18nEnabled.value ? locale.value : undefined),
   })
 
-  // Canonical link, plus the markdown twin as an alternate representation
-  useCanonical(() => route.path === '/' ? '/index.md' : `${route.path}.md`)
+  // Canonical link, plus the markdown twin as an alternate representation. A
+  // page's twin is its own URL plus `.md`, except at the site root, where the
+  // document only has a raw URL.
+  const rawPrefix = useRuntimeConfig().public.agentDiscovery?.rawPrefix || '/raw'
+  useCanonical(() => route.path === '/' ? `${rawPrefix}/index.md` : `${route.path}.md`)
 
   // Hreflang tags for i18n
   useHead({

--- a/layer/app/types/index.d.ts
+++ b/layer/app/types/index.d.ts
@@ -11,6 +11,10 @@ export interface DocusSeoOrganization {
   logo?: string
   /** Profile URLs (GitHub, X, LinkedIn…). */
   sameAs?: string[]
+  /** Postal address, as a schema.org `PostalAddress`. */
+  address?: Record<string, unknown>
+  /** Ways to reach the organization, as schema.org `ContactPoint` nodes. */
+  contactPoint?: Record<string, unknown> | Record<string, unknown>[]
 }
 
 declare module 'nuxt/schema' {

--- a/layer/nuxt.config.ts
+++ b/layer/nuxt.config.ts
@@ -26,6 +26,7 @@ export default defineNuxtConfig({
     '@nuxtjs/robots',
     '@nuxtjs/sitemap',
     '@nuxtjs/mcp-toolkit',
+    'nuxt-schema-org',
     'nuxt-og-image',
     'nuxt-llms',
     () => {

--- a/layer/package.json
+++ b/layer/package.json
@@ -54,6 +54,7 @@
     "nuxt-agent-discovery": "^0.5.0",
     "nuxt-llms": "^0.2.0",
     "nuxt-og-image": "~6.7.8",
+    "nuxt-schema-org": "^6.3.1",
     "pathe": "^2.0.3",
     "pkg-types": "^2.3.1",
     "scule": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,9 @@ importers:
       nuxt-og-image:
         specifier: ~6.7.8
         version: 6.7.8(a2f223c9744c14c7cfc6309993019ba4)
+      nuxt-schema-org:
+        specifier: ^6.3.1
+        version: 6.3.1(e61a5479cfea190d4259b579055a763c)
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -7303,6 +7306,20 @@ packages:
       tailwindcss:
         optional: true
       unifont:
+        optional: true
+      zod:
+        optional: true
+
+  nuxt-schema-org@6.3.1:
+    resolution: {integrity: sha512-pZQyLERx8iho4QDCDNK0WxfdHwmZWXk8Nrp9DUfR79aKkwivm83SEvwWp0D9/YuBfaXhm+9YxVBpCDA2kr8B+g==}
+    peerDependencies:
+      '@unhead/vue': ^2.0.7 || ^3.0.0
+      unhead: ^2.0.7 || ^3.0.0
+      zod: '>=3'
+    peerDependenciesMeta:
+      '@unhead/vue':
+        optional: true
+      unhead:
         optional: true
       zod:
         optional: true
@@ -18554,6 +18571,29 @@ snapshots:
       - vite
       - vue
       - webpack
+
+  nuxt-schema-org@6.3.1(e61a5479cfea190d4259b579055a763c):
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)))
+      defu: 6.1.7
+      nuxt-site-config: 4.2.3(85f7dfa1e4059a8a27c6a99658075a30)
+      nuxtseo-shared: 5.3.14(de7b830f3d6c39c786520bcf47f6e17d)
+      pkg-types: 2.3.1
+      ufo: 1.6.4
+    optionalDependencies:
+      '@unhead/vue': 3.3.2(@oxc-project/types@0.144.0)(esbuild@0.28.1)(lightningcss@1.33.0)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup@4.62.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+      unhead: 3.3.2(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0))
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@nuxt/schema'
+      - magic-string
+      - magicast
+      - nuxt
+      - oxc-parser
+      - rolldown
+      - unplugin
+      - vite
+      - vue
 
   nuxt-site-config-kit@4.2.3(magic-string@1.2.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.4)(rollup@4.62.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.12)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3)):
     dependencies:


### PR DESCRIPTION
`useSeo` was building the canonical link and the whole JSON-LD graph by hand. Both have a module behind them now.

## Canonical

`useCanonical()` from `nuxt-agent-discovery` replaces the canonical link we were computing from `site.url` and `route.path`. It also adds the `rel="alternate" type="text/markdown"` link we were not emitting at all, pointing at the page's `.md` twin, or at `/raw/index.md` on the site root, where the document has no twin URL of its own. The hreflang alternates stay hand written: `useLocaleHead` would bring its own canonical back.

## JSON-LD

`nuxt-schema-org` replaces the three `useHead` script blocks:

- doc pages get `defineArticle({ '@type': 'TechArticle' })` and `defineBreadcrumb()`, plus the `WebSite` and `WebPage` nodes the module emits on its own
- the landing gets `defineWebSite()`, the publisher `Organization` and the identity node (`defineSoftwareApp`, `defineProduct`, `definePerson` or `defineOrganization`) from `seo.schema`

`seo.schema` in `app.config.ts` keeps the same shape, so nothing changes for sites already using it. `organization` now also passes through `address` and `contactPoint`, which the module types and Google read but we had no way to declare.

The parent company is nested inside the publisher `Organization` instead of being a second node linked by `@id`, since the module owns the ids now.

## Checks

Rendered head on the docs site, landing and a doc page: one canonical, the markdown alternate, hreflang en/fr/x-default, and a graph of `WebSite`, `WebPage`, `Organization` with the nested parent, `SoftwareApplication` and the logo on the landing, `TechArticle` and `BreadcrumbList` on the doc page. Same check on the playground for a site without i18n.

Docs updated, en and fr.